### PR TITLE
Added missing dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,8 @@ setuptools.setup(
     py_modules=['onelogin_aws_cli'],
     install_requires=[
         'boto3',
-        'requests'
+        'requests',
+        'configparser',
     ],
     license='MIT License',
     scripts=['bin/onelogin-aws-login'],


### PR DESCRIPTION
When running `$ onelogin-aws-login -c` I got the error:

```
bash-3.2$ onelogin-aws-login -c
Traceback (most recent call last):
  File "/Users/drews/.pyenv/versions/2.7.12/bin/onelogin-aws-login", line 6, in <module>
    from onelogin_aws_cli import OneloginAWS
  File "/Users/drews/.pyenv/versions/2.7.12/lib/python2.7/site-packages/onelogin_aws_cli/__init__.py", line 3, in <module>
    import configparser
ImportError: No module named configparser

```
Installing configparser fixed this error