### PR TITLE
Fix the bug which is preventing one from selecting the first role

### DIFF
--- a/onelogin_aws_cli/__init__.py
+++ b/onelogin_aws_cli/__init__.py
@@ -151,7 +151,7 @@ class OneloginAWS(object):
             for role, principal in self.all_roles:
                 print("[{}] {}".format(ind, role))
                 ind += 1
-            while not selected_role:
+            while selected_role is None:
                 choice = int(input("Role Number: "))
                 if choice in range(len(self.all_roles)):
                     selected_role = choice


### PR DESCRIPTION
Without this fix, it seems like you just get prompted for a choice again and again even though you've input `0`:
```
$ onelogin-aws-login
Onelogin Username: mumoshu@example.com
Onelogin Password:
OTP Token: 936070
[0] arn:aws:iam::$myaccountid:role/myrole1
[1] arn:aws:iam::$myaccountid:role/myrole2
[2] arn:aws:iam::$myaccountid:role/myrole3
Role Number: 0
Role Number: 0
Role Number: 0
...
```

@physera Btw, thanks for sharing the great project 👍 Hope this helps.
