### PR TITLE
Add long/short options for CLI

### DIFF
--- a/bin/onelogin-aws-login
+++ b/bin/onelogin-aws-login
@@ -6,9 +6,9 @@ import sys
 from onelogin_aws_cli import OneloginAWS
 
 parser = argparse.ArgumentParser(description="Login to AWS with Onelogin")
-parser.add_argument("-c", dest="configure", action="store_true",
+parser.add_argument("-c", "--configure", dest="configure", action="store_true",
                     help="Configure Onelogin and AWS settings")
-parser.add_argument("--config_name", default="default",
+parser.add_argument("-C", "--config_name", default="default",
                     help="Switch configuration name within config file")
 
 args = parser.parse_args()


### PR DESCRIPTION
Hi there.

This tools is SO COOL! I was waiting for such a tool!
But, I feel hassle when I should type `--config_name` option every time to execute 'onelogin-aws-login' because we manage some AWS accounts on OneLogin.

Since I want to ease to run this command, I added `-C` option instead of `--config_name`.

Best regards.