### PR TITLE
Add -u / --username flag to specify an username from the command-line

### DIFF
--- a/bin/onelogin-aws-login
+++ b/bin/onelogin-aws-login
@@ -12,6 +12,8 @@ parser.add_argument("-C", "--config_name", default="default",
                     help="Switch configuration name within config file")
 parser.add_argument("--profile", default="",
                     help="Specify profile name of credential")
+parser.add_argument("-u", "--username", default="",
+                    help="Specify OneLogin username")
 
 args = parser.parse_args()
 

--- a/onelogin_aws_cli/__init__.py
+++ b/onelogin_aws_cli/__init__.py
@@ -76,7 +76,7 @@ class OneloginAWS(object):
         if not self.token:
             self.get_token()
 
-        email = input("Onelogin Username: ")
+        email = self.args.username or input("Onelogin Username: ")
         password = getpass.getpass("Onelogin Password: ")
         params = {
             "app_id": self.config["aws_app_id"],


### PR DESCRIPTION
so that you no longer need to input the same username again and again, after something like
```
alias o='onelogin-aws-login -u mumoshu@example.com'
```
is configured on your shell.