### PR TITLE
Auto-renew

### DIFF
--- a/bin/onelogin-aws-login
+++ b/bin/onelogin-aws-login
@@ -15,8 +15,8 @@ parser.add_argument("--profile", default="",
                     help="Specify profile name of credential")
 parser.add_argument("-u", "--username", default="",
                     help="Specify OneLogin username")
-parser.add_argument("-r", "--renew", action="store_true",
-                    help="Auto-renew credentials while session is active")
+parser.add_argument("-r", "--renewSeconds", type=int,
+                    help="Auto-renew credentials after this many seconds")
 
 args = parser.parse_args()
 
@@ -32,7 +32,7 @@ if not config or args.config_name not in config:
 api = OneloginAWS(config[args.config_name], args)
 api.save_credentials()
 
-if args.renew:
+if args.renewSeconds:
     while True:
-        time.sleep(3540)
+        time.sleep(args.renewSeconds)
         api.save_credentials()

--- a/bin/onelogin-aws-login
+++ b/bin/onelogin-aws-login
@@ -2,6 +2,7 @@
 
 import argparse
 import sys
+import time
 
 from onelogin_aws_cli import OneloginAWS
 
@@ -14,6 +15,8 @@ parser.add_argument("--profile", default="",
                     help="Specify profile name of credential")
 parser.add_argument("-u", "--username", default="",
                     help="Specify OneLogin username")
+parser.add_argument("-r", "--renew", action="store_true",
+                    help="Auto-renew credentials while session is active")
 
 args = parser.parse_args()
 
@@ -28,3 +31,8 @@ if not config or args.config_name not in config:
 
 api = OneloginAWS(config[args.config_name], args)
 api.save_credentials()
+
+if args.renew:
+    while True:
+        time.sleep(3540)
+        api.save_credentials()

--- a/onelogin_aws_cli/__init__.py
+++ b/onelogin_aws_cli/__init__.py
@@ -46,6 +46,9 @@ class OneloginAWS(object):
         self.principal_arn = None
         self.credentials = None
 
+        self.username = self.args.username
+        self.password = None
+
     def request(self, path, headers, data):
         res = requests.post(
             self.config["base_uri"] + path,
@@ -76,12 +79,14 @@ class OneloginAWS(object):
         if not self.token:
             self.get_token()
 
-        email = self.args.username or input("Onelogin Username: ")
-        password = getpass.getpass("Onelogin Password: ")
+        if not self.username:
+            self.username = input("Onelogin Username: ")
+        if not self.password:
+            self.password = getpass.getpass("Onelogin Password: ")
         params = {
             "app_id": self.config["aws_app_id"],
-            "username_or_email": email,
-            "password": password,
+            "username_or_email": self.username,
+            "password": self.password,
             "subdomain": self.config["subdomain"]
         }
         headers = {

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import setuptools
 setuptools.setup(
     name='onelogin_aws_cli',
     packages=['onelogin_aws_cli'],
-    version='0.1.5',
+    version='0.1.6',
 
     description='Onelogin assume AWS role through CLI',
     classifiers=[
@@ -18,7 +18,7 @@ setuptools.setup(
     author='Cameron Marlow',
     author_email='cameron@physera.com',
     url='https://github.com/physera/onelogin-aws-cli',
-    download_url='https://github.com/physera/onelogin-aws-cli/archive/0.1.5.tar.gz',  # noqa: E501
+    download_url='https://github.com/physera/onelogin-aws-cli/archive/0.1.6.tar.gz',  # noqa: E501
     py_modules=['onelogin_aws_cli'],
     install_requires=[
         'boto3',


### PR DESCRIPTION
One of the challenges of working with Assumed SAML roles in AWS is that they have a 60 minute maximum timeout for all temporary credentials for these assumed roles. AWS has [committed to extending this](https://forums.aws.amazon.com/thread.jspa?threadID=178944), but have only updated the AWS console timeout (not the CLI).

To address this, I propose we support a renew option that allows for the credentials to be renewed every 59 minutes in the background.

* Add an option in script to renew credentials every 59 minutes
* Store username and password on object for renewal