### PR TITLE
Enable re-login

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2017 Health Coda
+Copyright (c) 2017 Physera
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import setuptools
 setuptools.setup(
     name='onelogin_aws_cli',
     packages=['onelogin_aws_cli'],
-    version='0.1.6',
+    version='0.2.0',
 
     description='Onelogin assume AWS role through CLI',
     classifiers=[
@@ -18,7 +18,7 @@ setuptools.setup(
     author='Cameron Marlow',
     author_email='cameron@physera.com',
     url='https://github.com/physera/onelogin-aws-cli',
-    download_url='https://github.com/physera/onelogin-aws-cli/archive/0.1.6.tar.gz',  # noqa: E501
+    download_url='https://github.com/physera/onelogin-aws-cli/archive/0.2.0.tar.gz',  # noqa: E501
     py_modules=['onelogin_aws_cli'],
     install_requires=[
         'boto3',


### PR DESCRIPTION
This PR makes the client persist correctly in the case that you're running it in a loop. Unfortunately, if you have a policy that requires MFA, you will have to re-authenticate with the MFA each time it refreshes, but this is the best we can do for now.

see this for more context from the onelogin team: https://stackoverflow.com/questions/40336144/aws-api-credentials-with-onelogin-saml-and-mfa/47065404#47065404

* Factor out OTP validation into a separate method
* Enable retries on login and OTP validation to enable mistakes
* Reuse `user_choice` method for getting factors