### PR TITLE
Re-factored to use the official onelogin client

### DIFF
--- a/onelogin_aws_cli/__init__.py
+++ b/onelogin_aws_cli/__init__.py
@@ -1,14 +1,13 @@
 #!/usr/bin/env python3
 
+import base64
 import configparser
 import getpass
-import json
 import os
-import base64
 import xml.etree.ElementTree as ET
 
-import requests
 import boto3
+from onelogin.api.client import OneLoginClient
 
 CONFIG_FILENAME = ".onelogin-aws.config"
 
@@ -17,7 +16,7 @@ def user_choice(question, options):
     print(question + "\n")
     option_list = ""
     for i in range(0, len(options)):
-        option_list += ("{}. {}\n".format(i+1, options[i]))
+        option_list += ("{}. {}\n".format(i + 1, options[i]))
     selection = None
     while not selection:
         print(option_list)

--- a/onelogin_aws_cli/__init__.py
+++ b/onelogin_aws_cli/__init__.py
@@ -70,21 +70,20 @@ class OneloginAWS(object):
         )
 
         if saml_resp.mfa:
-            device_id = None
             devices = saml_resp.mfa.devices
             if len(devices) > 1:
                 for i, device in enumerate(devices):
                     print("{}. {}".format(i + 1, device.type))
                 device_num = input("Which OTP Device? ")
-                device_id = devices[int(device_num) - 1].id
+                device = devices[int(device_num) - 1]
             else:
-                device_id = devices[0].id
+                device = devices[0]
 
             otp_token = input("OTP Token: ")
 
             saml_resp = self.ol_client.get_saml_assertion_verifying(
                 self.config['app_id'],
-                device_id,
+                device.id,
                 saml_resp.mfa.state_token,
                 otp_token
             )

--- a/onelogin_aws_cli/__init__.py
+++ b/onelogin_aws_cli/__init__.py
@@ -18,7 +18,7 @@ def user_choice(question, options):
     for i, option in enumerate(options):
         option_list += ("{}. {}\n".format(i + 1, option))
     selection = None
-    while not selection:
+    while selection is None:
         print(option_list)
         choice = input("? ")
         try:
@@ -64,7 +64,7 @@ class OneloginAWS(object):
         saml_resp = self.ol_client.get_saml_assertion(
             self.username,
             self.password,
-            self.config['app_id'],
+            self.config['aws_app_id'],
             self.config['subdomain']
         )
 
@@ -81,7 +81,7 @@ class OneloginAWS(object):
             otp_token = input("OTP Token: ")
 
             saml_resp = self.ol_client.get_saml_assertion_verifying(
-                self.config['app_id'],
+                self.config['aws_app_id'],
                 device.id,
                 saml_resp.mfa.state_token,
                 otp_token

--- a/onelogin_aws_cli/__init__.py
+++ b/onelogin_aws_cli/__init__.py
@@ -15,8 +15,8 @@ CONFIG_FILENAME = ".onelogin-aws.config"
 def user_choice(question, options):
     print(question + "\n")
     option_list = ""
-    for i in range(0, len(options)):
-        option_list += ("{}. {}\n".format(i + 1, options[i]))
+    for i, option in enumerate(options):
+        option_list += ("{}. {}\n".format(i + 1, option))
     selection = None
     while not selection:
         print(option_list)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 boto3
-requests
+onelogin

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,6 @@ setuptools.setup(
     py_modules=['onelogin_aws_cli'],
     install_requires=[
         'boto3',
-        'requests',
         'onelogin'
     ],
     license='MIT License',

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,8 @@ setuptools.setup(
     py_modules=['onelogin_aws_cli'],
     install_requires=[
         'boto3',
-        'requests'
+        'requests',
+        'onelogin'
     ],
     license='MIT License',
     scripts=['bin/onelogin-aws-login'],


### PR DESCRIPTION
This PR removes custom http code and simplifies the code by using the [official onelogin](https://github.com/onelogin/onelogin-python-sdk) python SDK.

This is in relation to #32 . I think the better way to go about extending the session, is rather than try to use AWS to generate longer sts session, use onelogin to re-auth. This is already being done with the `renewSeconds` option, but if MFA is enabled the user must re-enter their MFA tokens every hour. I will propose to use the refresh tokens in onelogin to have longer periods where MFA is not required. 

Using the onelogin sdk will reduce the amount of code required to do this.

Using a client library will also make generating mocks for tests significantly easier