### PR TITLE
Shifted bin script into setup.py endpoints

### DIFF
--- a/bin/onelogin-aws-login
+++ b/bin/onelogin-aws-login
@@ -1,44 +1,8 @@
 #!/usr/bin/env python3
 
-import argparse
 import sys
-import time
 
-import pkg_resources
+from onelogin_aws_cli.cli import login
 
-from onelogin_aws_cli import OneloginAWS
-
-version = pkg_resources.get_distribution('pip').version
-
-parser = argparse.ArgumentParser(description="Login to AWS with Onelogin")
-parser.add_argument("-c", "--configure", dest="configure", action="store_true",
-                    help="Configure Onelogin and AWS settings")
-parser.add_argument("-C", "--config_name", default="default",
-                    help="Switch configuration name within config file")
-parser.add_argument("--profile", default="",
-                    help="Specify profile name of credential")
-parser.add_argument("-u", "--username", default="",
-                    help="Specify OneLogin username")
-parser.add_argument("-r", "--renewSeconds", type=int,
-                    help="Auto-renew credentials after this many seconds")
-parser.add_argument('-v', '--version', action='version',
-                    version='%(prog)s ' + version)
-
-args = parser.parse_args()
-
-if args.configure:
-    OneloginAWS.generate_config()
-
-config = OneloginAWS.load_config()
-
-if not config or args.config_name not in config:
-    sys.exit("Configuration '{}' not defined. "
-             "Please run 'onelogin-aws-login -c'".format(args.config_name))
-
-api = OneloginAWS(config[args.config_name], args)
-api.save_credentials()
-
-if args.renewSeconds:
-    while True:
-        time.sleep(args.renewSeconds)
-        api.save_credentials()
+if __name__ == '__main__':
+    login(args=sys.argv[1:])

--- a/bin/onelogin-aws-login
+++ b/bin/onelogin-aws-login
@@ -1,8 +1,0 @@
-#!/usr/bin/env python3
-
-import sys
-
-from onelogin_aws_cli.cli import login
-
-if __name__ == '__main__':
-    login(args=sys.argv[1:])

--- a/onelogin_aws_cli/cli.py
+++ b/onelogin_aws_cli/cli.py
@@ -1,0 +1,49 @@
+import argparse
+import sys
+import time
+
+import pkg_resources
+
+from onelogin_aws_cli import OneloginAWS
+
+
+def login(args=sys.argv[1:]):
+    """
+    Entrypoint for `onelogin-aws-login`
+    :param args:
+    """
+    version = pkg_resources.get_distribution('pip').version
+
+    parser = argparse.ArgumentParser(description="Login to AWS with Onelogin")
+    parser.add_argument("-c", "--configure", dest="configure",
+                        action="store_true",
+                        help="Configure Onelogin and AWS settings")
+    parser.add_argument("-C", "--config_name", default="default",
+                        help="Switch configuration name within config file")
+    parser.add_argument("--profile", default="",
+                        help="Specify profile name of credential")
+    parser.add_argument("-u", "--username", default="",
+                        help="Specify OneLogin username")
+    parser.add_argument("-r", "--renewSeconds", type=int,
+                        help="Auto-renew credentials after this many seconds")
+    parser.add_argument('-v', '--version', action='version',
+                        version='%(prog)s ' + version)
+
+    args = parser.parse_args(args)
+
+    if args.configure:
+        OneloginAWS.generate_config()
+
+    config = OneloginAWS.load_config()
+
+    if not config or args.config_name not in config:
+        sys.exit("Configuration '{}' not defined. "
+                 "Please run 'onelogin-aws-login -c'".format(args.config_name))
+
+    api = OneloginAWS(config[args.config_name], args)
+    api.save_credentials()
+
+    if args.renewSeconds:
+        while True:
+            time.sleep(args.renewSeconds)
+            api.save_credentials()

--- a/setup.py
+++ b/setup.py
@@ -24,8 +24,12 @@ setuptools.setup(
         'boto3',
         'onelogin'
     ],
+    entry_points={
+        "console_scripts": [
+            "onelogin-aws-login = onelogin_aws_cli.cli:login"
+        ]
+    },
     license='MIT License',
-    scripts=['bin/onelogin-aws-login'],
     test_suite='nose.collector',
     tests_require=['nose', 'nose-cover3'],
     zip_safe=False,


### PR DESCRIPTION
To make testing easier, shift the cli entrypoints into functions exposed by setup and distutils.

This will also reduce the size of PR #39 