### PR TITLE
Add include/exclude rules for python coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,7 @@
+[paths]
+source =
+    onelogin_aws_cli/*.py
+
+[run]
+omit =
+    */tests/*


### PR DESCRIPTION
When running coverage tests, the test cases themselves are included at the moment.

This will exclude the test cases from coverage metrics.