### PR TITLE
Add code coverage output to travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 python: "3.6"
 install:
-  - pip install -r requirements.txt
   - pip install flake8
 before_script:
   - flake8 .

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,11 @@
 language: python
 python:
-  - "3.2"
-  - "3.3"
-  - "3.4"
   - "3.5"
   - "3.6"
   - "3.7-dev"
 matrix:
   allow_failures:
-  - python: 3.2
-  - python: 3.3
-  - python: 3.4
-  - python: 3.5
-  - python: 3.7-dev
+    - python: 3.7-dev
 install:
   - pip install flake8 codecov
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,4 @@ install:
   - pip install flake8
 before_script:
   - flake8 .
-script: python -m unittest -v
+script: python setup.py nosetests

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,18 @@
 language: python
-python: "3.6"
+python:
+  - "3.2"
+  - "3.3"
+  - "3.4"
+  - "3.5"
+  - "3.6"
+  - "3.7-dev"
+matrix:
+  allow_failures:
+  - python: 3.2
+  - python: 3.3
+  - python: 3.4
+  - python: 3.5
+  - python: 3.7-dev
 install:
   - pip install flake8 codecov
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 language: python
 python: "3.6"
 install:
-  - pip install flake8
+  - pip install flake8 codecov
 before_script:
   - flake8 .
 script: python setup.py nosetests
+after_success:
+  - codecov

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 Assume an AWS Role and cache credentials using Onelogin
 
 [![Build Status](https://travis-ci.org/physera/onelogin-aws-cli.svg?branch=master)](https://travis-ci.org/physera/onelogin-aws-cli)
+[![codecov](https://codecov.io/gh/physera/onelogin-aws-cli/branch/master/graph/badge.svg)](https://codecov.io/gh/physera/onelogin-aws-cli)
 
 This package provides a script to login to Onelogin and use a SAML connection
 to AWS to assume a role. More details on setting up SAML for AWS can be found

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,11 @@
 [metadata]
 description-file = README.md
+
+[nosetests]
+verbosity=1
+detailed-errors=1
+with-coverage=1
+cover-package=onelogin_aws_cli
+debug=nose.loader
+pdb=1
+pdb-failures=1

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ setuptools.setup(
         'onelogin',
         'keyring'
     ],
+    setup_requires=['nose>=1.0'],
     entry_points={
         "console_scripts": [
             "onelogin-aws-login = onelogin_aws_cli.cli:login"

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ setuptools.setup(
     name='onelogin_aws_cli',
     packages=['onelogin_aws_cli'],
     version='0.1.8',
-    python_requires='>=3',
+    python_requires='>=3.5',
     description='Onelogin assume AWS role through CLI',
     classifiers=[
         'Development Status :: 4 - Beta',

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,6 @@ setuptools.setup(
     },
     license='MIT License',
     test_suite='nose.collector',
-    tests_require=['nose', 'nose-cover3'],
+    tests_require=['coverage', 'nose', 'nose-cover3'],
     zip_safe=False,
 )


### PR DESCRIPTION
Modiy travis config to use nosetests to output code coverage for tests as part of build.
Eventually (if there's interest), I'd like to add https://codecov.io/ to the build process.

This can be a check in the PR, or just informative, eg https://github.com/drewsonne/terraform-provider-gocd/pull/40#issuecomment-353984463

Working demonstration of new travis configs: https://travis-ci.org/drewsonne/onelogin-aws-cli/builds/353686140