### PR TITLE
Fix a bug when config file does not exist

### DIFF
--- a/onelogin_aws_cli/cli.py
+++ b/onelogin_aws_cli/cli.py
@@ -39,12 +39,12 @@ def login(args=sys.argv[1:]):
 
     with open(DEFAULT_CONFIG_PATH, 'a+') as fp:
         fp.seek(0, 0)
-        configFile = ConfigurationFile(fp)
+        config_file = ConfigurationFile(fp)
 
-    if args.configure or not configFile.is_initialised:
-        configFile.initialise()
+    if args.configure or not config_file.is_initialised:
+        config_file.initialise()
 
-    config_section = configFile.section(args.config_name)
+    config_section = config_file.section(args.config_name)
 
     if config_section is None:
         sys.exit("Configuration '{}' not defined. "

--- a/onelogin_aws_cli/cli.py
+++ b/onelogin_aws_cli/cli.py
@@ -37,10 +37,11 @@ def login(args=sys.argv[1:]):
 
     args = parser.parse_args(args)
 
-    with open(DEFAULT_CONFIG_PATH) as fp:
+    with open(DEFAULT_CONFIG_PATH, 'a+') as fp:
+        fp.seek(0, 0)
         configFile = ConfigurationFile(fp)
 
-    if args.configure:
+    if args.configure or not configFile.is_initialised:
         configFile.initialise()
 
     config_section = configFile.section(args.config_name)

--- a/onelogin_aws_cli/configuration.py
+++ b/onelogin_aws_cli/configuration.py
@@ -21,7 +21,7 @@ class ConfigurationFile(configparser.ConfigParser):
         self.read_file(self.file)
 
     @property
-    def is_initialised(self):
+    def is_initialised(self) -> bool:
         """
         True is there are at least one section
         """

--- a/onelogin_aws_cli/configuration.py
+++ b/onelogin_aws_cli/configuration.py
@@ -23,7 +23,7 @@ class ConfigurationFile(configparser.ConfigParser):
     @property
     def is_initialised(self) -> bool:
         """
-        True is there are at least one section
+        True if there is at least one section
         """
         return len(
             self.sections()

--- a/onelogin_aws_cli/configuration.py
+++ b/onelogin_aws_cli/configuration.py
@@ -20,6 +20,15 @@ class ConfigurationFile(configparser.ConfigParser):
 
         self.read_file(self.file)
 
+    @property
+    def is_initialised(self):
+        """
+        True is there are at least one section
+        """
+        return len(
+            self.sections()
+        ) > 0
+
     def initialise(self):
         """
         Prompt the user for configurations, and save them to the


### PR DESCRIPTION
If `~/.onelogin-aws.config` does not exist and `onelogin-aws-login` was called as described in the readme an error would be thrown:
```
$ onelogin-aws-login
Traceback (most recent call last):
  File "/.../python-3.6.3/bin/onelogin-aws-login", line 11, in <module>
    load_entry_point('onelogin-aws-cli', 'console_scripts', 'onelogin-aws-login')()
  File "/.../onelogin_aws_cli/cli.py", line 40, in login
    with open(DEFAULT_CONFIG_PATH, 'r+') as fp:
FileNotFoundError: [Errno 2] No such file or directory: '/Users/.../.onelogin-aws.config'
```