### PR TITLE
Fix bug where config name not being passed on init

### DIFF
--- a/onelogin_aws_cli/cli.py
+++ b/onelogin_aws_cli/cli.py
@@ -42,7 +42,7 @@ def login(args=sys.argv[1:]):
         config_file = ConfigurationFile(fp)
 
     if args.configure or not config_file.is_initialised:
-        config_file.initialise()
+        config_file.initialise(args.config_name)
 
     config_section = config_file.section(args.config_name)
 

--- a/onelogin_aws_cli/configuration.py
+++ b/onelogin_aws_cli/configuration.py
@@ -29,13 +29,13 @@ class ConfigurationFile(configparser.ConfigParser):
             self.sections()
         ) > 0
 
-    def initialise(self):
+    def initialise(self, config_name='default'):
         """
         Prompt the user for configurations, and save them to the
         onelogin-aws-cli config file
         """
         print("Configure Onelogin and AWS\n\n")
-        default = self.section("default")
+        default = self.section(config_name)
 
         default['base_uri'] = user_choice("Pick a Onelogin API server:", [
             "https://api.us.onelogin.com/",

--- a/onelogin_aws_cli/configuration.py
+++ b/onelogin_aws_cli/configuration.py
@@ -37,10 +37,12 @@ class ConfigurationFile(configparser.ConfigParser):
         print("Configure Onelogin and AWS\n\n")
         config_section = self.section(config_name)
 
-        config_section['base_uri'] = user_choice("Pick a Onelogin API server:", [
-            "https://api.us.onelogin.com/",
-            "https://api.eu.onelogin.com/"
-        ])
+        config_section['base_uri'] = user_choice(
+            "Pick a Onelogin API server:", [
+                "https://api.us.onelogin.com/",
+                "https://api.eu.onelogin.com/"
+            ]
+        )
 
         print("\nOnelogin API credentials. These can be found at:\n"
               "https://admin.us.onelogin.com/api_credentials")

--- a/onelogin_aws_cli/configuration.py
+++ b/onelogin_aws_cli/configuration.py
@@ -35,23 +35,23 @@ class ConfigurationFile(configparser.ConfigParser):
         onelogin-aws-cli config file
         """
         print("Configure Onelogin and AWS\n\n")
-        default = self.section(config_name)
+        config_section = self.section(config_name)
 
-        default['base_uri'] = user_choice("Pick a Onelogin API server:", [
+        config_section['base_uri'] = user_choice("Pick a Onelogin API server:", [
             "https://api.us.onelogin.com/",
             "https://api.eu.onelogin.com/"
         ])
 
         print("\nOnelogin API credentials. These can be found at:\n"
               "https://admin.us.onelogin.com/api_credentials")
-        default['client_id'] = input("Onelogin API Client ID: ")
-        default['client_secret'] = input("Onelogin API Client Secret: ")
+        config_section['client_id'] = input("Onelogin API Client ID: ")
+        config_section['client_secret'] = input("Onelogin API Client Secret: ")
         print("\nOnelogin AWS App ID. This can be found at:\n"
               "https://admin.us.onelogin.com/apps")
-        default['aws_app_id'] = input("Onelogin App ID for AWS: ")
+        config_section['aws_app_id'] = input("Onelogin App ID for AWS: ")
         print("\nOnelogin subdomain is 'company' for login domain of "
               "'comany.onelogin.com'")
-        default['subdomain'] = input("Onelogin subdomain: ")
+        config_section['subdomain'] = input("Onelogin subdomain: ")
 
         self.save()
 


### PR DESCRIPTION
Fix a bug where the -c -C ... did not pass the config onto the initialise command.

Split out of #53 to reduce its size (a bit anyway...).