### PR TITLE
Separate Version and Package Name into constants

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,13 @@
 import setuptools
 
+PACKAGE_NAME = 'onelogin_aws_cli'
+VERSION = '0.1.8'
 
 setuptools.setup(
-    name='onelogin_aws_cli',
-    packages=['onelogin_aws_cli'],
-    version='0.1.8',
-    python_requires='>=3.5',
+    name=PACKAGE_NAME,
+    packages=[PACKAGE_NAME],
+    version=VERSION,
+    python_requires='>=3',
     description='Onelogin assume AWS role through CLI',
     classifiers=[
         'Development Status :: 4 - Beta',
@@ -21,8 +23,12 @@ setuptools.setup(
     author='Cameron Marlow',
     author_email='cameron@physera.com',
     url='https://github.com/physera/onelogin-aws-cli',
-    download_url='https://github.com/physera/onelogin-aws-cli/archive/0.1.8.tar.gz',  # noqa: E501
-    py_modules=['onelogin_aws_cli'],
+    download_url=(
+            'https://github.com/physera/onelogin-aws-cli/archive/' +
+            VERSION +
+            '.tar.gz'
+    ),
+    py_modules=[PACKAGE_NAME],
     install_requires=[
         'boto3',
         'onelogin',
@@ -31,7 +37,7 @@ setuptools.setup(
     setup_requires=['nose>=1.0'],
     entry_points={
         "console_scripts": [
-            "onelogin-aws-login = onelogin_aws_cli.cli:login"
+            "onelogin-aws-login = {pkg}.cli:login".format(pkg=PACKAGE_NAME)
         ]
     },
     license='MIT License',


### PR DESCRIPTION
I did this initially because when testing the Arg parser, I wanted to be able to know what the package version was.

That was not necessary after using `pkg_resources`, but having a central place to change the version seemed like a good idea.

Split out of #53 to reduce its size (a bit anyway...).

