### PR TITLE
Stop coverage.py dropping into pdb

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -7,5 +7,5 @@ detailed-errors=1
 with-coverage=1
 cover-package=onelogin_aws_cli
 debug=nose.loader
-pdb=1
-pdb-failures=1
+pdb=0
+pdb-failures=0


### PR DESCRIPTION
If these flags are true, then when the test cases are run to collect coverage, if there is an error they will drop into pdb mode and pause waiting for user input to control the debugger.

This causes travis to hang and breaks the build