### PR TITLE
Enable to set the duration seconds more than 1 hour

### DIFF
--- a/onelogin_aws_cli/__init__.py
+++ b/onelogin_aws_cli/__init__.py
@@ -32,6 +32,7 @@ class OneloginAWS(object):
         self.role_arn = None
         self.principal_arn = None
         self.credentials = None
+        self.duration_seconds = args.duration_seconds
         self.user_credentials = UserCredentials(self.args.username, config)
         self.mfa = MFACredentials()
 
@@ -147,7 +148,8 @@ class OneloginAWS(object):
         res = self.sts_client.assume_role_with_saml(
             RoleArn=self.role_arn,
             PrincipalArn=self.principal_arn,
-            SAMLAssertion=self.saml.saml_response
+            SAMLAssertion=self.saml.saml_response,
+            DurationSeconds=self.duration_seconds
         )
 
         self.credentials = res

--- a/onelogin_aws_cli/argparse.py
+++ b/onelogin_aws_cli/argparse.py
@@ -26,6 +26,11 @@ class OneLoginAWSArgumentParser(argparse.ArgumentParser):
             '-u', '--username', default='', help='Specify OneLogin username'
         )
 
+        self.add_argument(
+            '-d', '--duration-seconds', type=int, default=3600, dest='duration_seconds',
+            help='Specify duration seconds which depend on IAM role session duration: https://aws.amazon.com/about-aws/whats-new/2018/03/longer-role-sessions/'
+        )
+
         version = pkg_resources.get_distribution(__package__).version
         self.add_argument(
             '-v', '--version', action='version',

--- a/onelogin_aws_cli/tests/test_oneLoginAWSArgumentParser.py
+++ b/onelogin_aws_cli/tests/test_oneLoginAWSArgumentParser.py
@@ -53,6 +53,7 @@ class TestOneLoginAWSArgumentParser(TestCase):
             '-u', 'my_username',
             '--renew-seconds', '30',
             '-c',
+            '-d', '43200',
         ])
 
         self.assertEqual(args.config_name, 'my_config')
@@ -60,6 +61,7 @@ class TestOneLoginAWSArgumentParser(TestCase):
         self.assertEqual(args.username, 'my_username')
         self.assertEqual(args.renew_seconds, 30)
         self.assertTrue(args.configure)
+        self.assertEqual(args.duration_seconds, 43200)
 
     def test_legacy_renew_seconds(self):
         parser = OneLoginAWSArgumentParser()


### PR DESCRIPTION
Hi there,

The other day, AWS has launched a new feature which is enable to us to set session duration to IAM roles.
https://aws.amazon.com/about-aws/whats-new/2018/03/longer-role-sessions/
This is what we have been waiting for a long time!

In this P-R, we can set `--duration-seconds` or `-d` option to increase session expiration more than 1 hour.
FYI, when we set `--duration-seconds` over the session duration, `onelogin-aws-cli` shows an error as follows:

```
Traceback (most recent call last):
  File "/Users/aibou/.local/bin/onelogin-aws-login", line 11, in <module>
    load_entry_point('onelogin-aws-cli==0.1.8', 'console_scripts', 'onelogin-aws-login')()
  File "/Users/aibou/.local/lib/python3.6/site-packages/onelogin_aws_cli-0.1.8-py3.6.egg/onelogin_aws_cli/cli.py", line 71, in login
    api.save_credentials()
  File "/Users/aibou/.local/lib/python3.6/site-packages/onelogin_aws_cli-0.1.8-py3.6.egg/onelogin_aws_cli/__init__.py", line 161, in save_credentials
    self.assume_role()
  File "/Users/aibou/.local/lib/python3.6/site-packages/onelogin_aws_cli-0.1.8-py3.6.egg/onelogin_aws_cli/__init__.py", line 152, in assume_role
    DurationSeconds=self.duration_seconds
  File "/Users/aibou/.local/lib/python3.6/site-packages/botocore/client.py", line 314, in _api_call
    return self._make_api_call(operation_name, kwargs)
  File "/Users/aibou/.local/lib/python3.6/site-packages/botocore/client.py", line 612, in _make_api_call
    raise error_class(parsed_response, operation_name)
botocore.exceptions.ClientError: An error occurred (ValidationError) when calling the AssumeRoleWithSAML operation: The requested DurationSeconds exceeds the MaxSessionDuration set for this role.
```