### PR TITLE
Do not distinguish between config sources

### DIFF
--- a/onelogin_aws_cli/__init__.py
+++ b/onelogin_aws_cli/__init__.py
@@ -22,16 +22,15 @@ class OneloginAWS(object):
     identity federation
     """
 
-    def __init__(self, config: Section, args):
+    def __init__(self, config: Section):
         self.sts_client = boto3.client("sts")
         self.config = config
-        self.args = args
         self.saml = None
         self.all_roles = None
         self.role_arn = None
         self.credentials = None
-        self.duration_seconds = args.duration_seconds
-        self.user_credentials = UserCredentials(self.args.username, config)
+        self.duration_seconds = config['duration_seconds']
+        self.user_credentials = UserCredentials(config)
         self.mfa = MFACredentials()
 
         base_uri_parts = self.config['base_uri'].split('.')
@@ -145,8 +144,6 @@ class OneloginAWS(object):
         name = name.replace(":assumed-role", "")
         if "profile" in self.config:
             name = self.config["profile"]
-        elif self.args.profile != "":
-            name = self.args.profile
 
         cred_config[name] = {
             "aws_access_key_id": creds["AccessKeyId"],

--- a/onelogin_aws_cli/cli.py
+++ b/onelogin_aws_cli/cli.py
@@ -66,7 +66,9 @@ def login(args=sys.argv[1:]):
     else:
         renew_seconds = None
 
-    api = OneloginAWS(config_section, args)
+    config_section.set_overrides(vars(args))
+
+    api = OneloginAWS(config_section)
     api.save_credentials()
 
     if renew_seconds:

--- a/onelogin_aws_cli/configuration.py
+++ b/onelogin_aws_cli/configuration.py
@@ -79,6 +79,7 @@ class Section(object):
     def __init__(self, section_name: str, config: ConfigurationFile):
         self.config = config
         self.section_name = section_name
+        self._overrides = {}
 
     @property
     def can_save_password(self) -> bool:
@@ -89,10 +90,20 @@ class Section(object):
         """
         return self.config.getboolean(self.section_name, "save_password")
 
+    def set_overrides(self, overrides: dict):
+        """
+        Specify a dictionary values which take precedence over the existing
+        values, but will not overwrite them in the config file.
+        :param overrides:
+        """
+        self._overrides = overrides
+
     def __setitem__(self, key, value):
         self.config.set(self.section_name, key, value)
 
     def __getitem__(self, item):
+        if item in self._overrides:
+            return self._overrides[item]
         return self.config.get(self.section_name, item)
 
     def __contains__(self, item):

--- a/onelogin_aws_cli/credentials.py
+++ b/onelogin_aws_cli/credentials.py
@@ -92,8 +92,8 @@ class UserCredentials(object):
     """
     SERVICE_NAME = "onelogin-aws-cli"
 
-    def __init__(self, username, config: Section):
-        self.username = username
+    def __init__(self, config: Section):
+        self.username = config['username']
         self.configuration = config
 
         # This is `None`, as the password should be be emitted from this class

--- a/onelogin_aws_cli/tests/test_oneloginAWS.py
+++ b/onelogin_aws_cli/tests/test_oneloginAWS.py
@@ -26,8 +26,8 @@ class TestOneloginAWS(TestCase):
             base_uri="https://api.us.onelogin.com/",
             client_id='mock-id',
             client_secret='mock-secret',
-            username = 'mock-username',
-           duration_seconds = 2600
+            username='mock-username',
+            duration_seconds=2600
         ))
 
     def test_init(self):
@@ -35,8 +35,8 @@ class TestOneloginAWS(TestCase):
             base_uri="https://api.us.onelogin.com/",
             client_id='mock-id',
             client_secret='mock-secret',
-            username = 'mock-username',
-           duration_seconds = 2600
+            username='mock-username',
+            duration_seconds=2600
         )
         ol = OneloginAWS(mock_config)
 

--- a/onelogin_aws_cli/tests/test_oneloginAWS.py
+++ b/onelogin_aws_cli/tests/test_oneloginAWS.py
@@ -25,26 +25,22 @@ class TestOneloginAWS(TestCase):
         self.ol = OneloginAWS(dict(
             base_uri="https://api.us.onelogin.com/",
             client_id='mock-id',
-            client_secret='mock-secret'
-        ), Namespace(
-            username='mock-username',
-            duration_seconds=2600
+            client_secret='mock-secret',
+            username = 'mock-username',
+           duration_seconds = 2600
         ))
 
     def test_init(self):
         mock_config = dict(
             base_uri="https://api.us.onelogin.com/",
             client_id='mock-id',
-            client_secret='mock-secret'
+            client_secret='mock-secret',
+            username = 'mock-username',
+           duration_seconds = 2600
         )
-        mock_args = Namespace(
-            username='mock-username',
-            duration_seconds=2600
-        )
-        ol = OneloginAWS(mock_config, mock_args)
+        ol = OneloginAWS(mock_config)
 
         self.assertEqual(mock_config, ol.config)
-        self.assertEqual(mock_args, ol.args)
         self.assertEqual('mock-username', ol.user_credentials.username)
 
     def test_get_arns(self):

--- a/onelogin_aws_cli/tests/test_oneloginAWS_saml.py
+++ b/onelogin_aws_cli/tests/test_oneloginAWS_saml.py
@@ -27,11 +27,9 @@ class TestOneloginSAML(TestCase):
                 aws_app_id='mock-app-id',
                 subdomain='example',
                 can_save_password=False,
-            ),
-            Namespace(
                 username='mock-username',
                 duration_seconds=2600
-            )
+            ),
         )
 
         self.ol.password = "mock-password"

--- a/onelogin_aws_cli/tests/test_section.py
+++ b/onelogin_aws_cli/tests/test_section.py
@@ -6,6 +6,19 @@ from onelogin_aws_cli import Section
 
 
 class TestSection(TestCase):
+
+    def test___contains__true(self):
+        sec = Section('mock-section', Namespace(
+            has_option=MagicMock(return_value=True)
+        ))
+        self.assertTrue('mock' in sec)
+
+    def test___contains__false(self):
+        sec = Section('mock-section', Namespace(
+            has_option=MagicMock(return_value=False)
+        ))
+        self.assertFalse('mock' in sec)
+
     def test_set_overrides(self):
         sec = Section('mock-section', Namespace(
             get=MagicMock(return_value='world')

--- a/onelogin_aws_cli/tests/test_section.py
+++ b/onelogin_aws_cli/tests/test_section.py
@@ -1,0 +1,20 @@
+from argparse import Namespace
+from unittest import TestCase
+from unittest.mock import MagicMock
+
+from onelogin_aws_cli import Section
+
+
+class TestSection(TestCase):
+    def test_set_overrides(self):
+        sec = Section('mock-section', Namespace(
+            get=MagicMock(return_value='world')
+        ))
+
+        self.assertEqual(sec['foo'], 'world')
+
+        sec.set_overrides(dict(
+            foo='bar'
+        ))
+
+        self.assertEqual(sec['foo'], 'bar')


### PR DESCRIPTION
Rather than distinguishing between whether an option comes from the config file or the cli/env var's, set an order of precedence and merge all the configuration options into one resource.

This means that there is no need for separate logic to handle cli or config options in the `OneloginAWS` class.

Addresses #76 