### PR TITLE
Fixed a bug where defaults would be overwritten

### DIFF
--- a/onelogin_aws_cli/argparse.py
+++ b/onelogin_aws_cli/argparse.py
@@ -79,9 +79,10 @@ class EnvDefault(argparse.Action):
         if 'dest' in kwargs:
             name = 'ONELOGIN_AWS_CLI_' + kwargs['dest'].upper()
             # Fall back to the explicit command line default.
-            default = os.environ.get(name, default)
-            if 'type' in kwargs and default is not None:
-                default = kwargs['type'](default)
+            if name in os.environ:
+                default = os.environ[name]
+                if 'type' in kwargs and default is not None:
+                    default = kwargs['type'](default)
 
         super().__init__(default=default, required=required, **kwargs)
 

--- a/onelogin_aws_cli/tests/test_oneLoginAWSArgumentParser.py
+++ b/onelogin_aws_cli/tests/test_oneLoginAWSArgumentParser.py
@@ -106,7 +106,6 @@ class TestOneLoginAWSArgumentParser(TestCase):
         del environ['ONELOGIN_AWS_CLI_DURATION_SECONDS']
         del environ['ONELOGIN_AWS_CLI_RENEW_SECONDS']
 
-
     def test_defaults(self):
 
         del environ['ONELOGIN_AWS_CLI_CONFIG_NAME']

--- a/onelogin_aws_cli/tests/test_oneLoginAWSArgumentParser.py
+++ b/onelogin_aws_cli/tests/test_oneLoginAWSArgumentParser.py
@@ -108,11 +108,10 @@ class TestOneLoginAWSArgumentParser(TestCase):
 
     def test_defaults(self):
 
-        del environ['ONELOGIN_AWS_CLI_CONFIG_NAME']
-        del environ['ONELOGIN_AWS_CLI_PROFILE']
-        del environ['ONELOGIN_AWS_CLI_USERNAME']
-        del environ['ONELOGIN_AWS_CLI_DURATION_SECONDS']
-        del environ['ONELOGIN_AWS_CLI_RENEW_SECONDS']
+        for name in ['ONELOGIN_AWS_CLI_CONFIG_NAME',
+                     'ONELOGIN_AWS_CLI_DURATION_SECONDS']:
+            if name in environ:
+                del environ[name]
 
         parser = OneLoginAWSArgumentParser()
 

--- a/onelogin_aws_cli/tests/test_oneLoginAWSArgumentParser.py
+++ b/onelogin_aws_cli/tests/test_oneLoginAWSArgumentParser.py
@@ -105,3 +105,19 @@ class TestOneLoginAWSArgumentParser(TestCase):
         del environ['ONELOGIN_AWS_CLI_USERNAME']
         del environ['ONELOGIN_AWS_CLI_DURATION_SECONDS']
         del environ['ONELOGIN_AWS_CLI_RENEW_SECONDS']
+
+
+    def test_defaults(self):
+
+        del environ['ONELOGIN_AWS_CLI_CONFIG_NAME']
+        del environ['ONELOGIN_AWS_CLI_PROFILE']
+        del environ['ONELOGIN_AWS_CLI_USERNAME']
+        del environ['ONELOGIN_AWS_CLI_DURATION_SECONDS']
+        del environ['ONELOGIN_AWS_CLI_RENEW_SECONDS']
+
+        parser = OneLoginAWSArgumentParser()
+
+        args = parser.parse_args([])
+
+        self.assertEqual(args.config_name, 'default')
+        self.assertEqual(args.duration_seconds, 3600)


### PR DESCRIPTION
In the previous case, defaults in the cli args would be overwritten and replaced with a null value even when no env vars were set.

I think this is a problem I introduced with https://github.com/physera/onelogin-aws-cli/pull/77 . This is pointed out in #83 .