### PR TITLE
Fix a number of bugs relating to config file defaults

### DIFF
--- a/onelogin_aws_cli/tests/test_configurationFile.py
+++ b/onelogin_aws_cli/tests/test_configurationFile.py
@@ -60,6 +60,16 @@ save_password = true
 [profile_test]""")
         self.assertTrue(cfg.section("profile_test").can_save_password)
 
+    def test_can_save_password_username_defaults_false(self):
+        cfg = self._helper_build_config("""[defaults]
+save_password = false""")
+        self.assertFalse(cfg.section(None).can_save_password)
+
+    def test_can_save_password_username_defaults_true(self):
+        cfg = self._helper_build_config("""[defaults]
+save_password = true""")
+        self.assertTrue(cfg.section(None).can_save_password)
+
     def test_initialise(self):
         str = StringIO()
         cfg = ConfigurationFile(str)
@@ -71,8 +81,6 @@ save_password = true
 
         self.assertEqual("""[defaults]
 save_password = False
-
-[default]
 base_uri = https://api.eu.onelogin.com/
 client_id = mock_client_id
 client_secret = mock_client_secret
@@ -90,3 +98,35 @@ subdomain = mock_subdomain
         cf = self._helper_build_config("""[section]
 first=foo""")
         self.assertTrue(cf.is_initialised)
+
+        cf = self._helper_build_config("""[defaults]
+first=foo""")
+        self.assertTrue(cf.is_initialised)
+
+    def test_has_defaults(self):
+
+        content = StringIO()
+        cf = ConfigurationFile(content)
+        self.assertFalse(cf.has_defaults)
+
+        cf = self._helper_build_config("""[defaults]
+first=foo""")
+        self.assertTrue(cf.has_defaults)
+
+    def test_supports_default(self):
+
+        cf = self._helper_build_config("""[defaults]
+first=foo""")
+        self.assertIn("first", cf.defaults())
+
+        cf = self._helper_build_config("""[default]
+second=bar""")
+        self.assertIn("second", cf.defaults())
+
+        cf = self._helper_build_config("""[defaults]
+first=foo
+
+[default]
+second=bar""")
+        self.assertIn("first", cf.defaults())
+        self.assertNotIn("second", cf.defaults())


### PR DESCRIPTION
* initialize should write to the default_section.
* handle the case where initialize is called without a section.
* handle legacy config files with default instead of defaults.
* handle config files without a profile section aside from the defaults.