### PR TITLE
Only create a section when we initialise

### DIFF
--- a/onelogin_aws_cli/configuration.py
+++ b/onelogin_aws_cli/configuration.py
@@ -20,11 +20,6 @@ class ConfigurationFile(configparser.ConfigParser):
             self.load()
 
     @property
-    def has_defaults(self) -> bool:
-        """True if the defaults section has settings beyond our defaults"""
-        return len(self[self.default_section]) > len(self.DEFAULTS)
-
-    @property
     def is_initialised(self) -> bool:
         """True if there is at least one section"""
         return len(

--- a/onelogin_aws_cli/tests/test_configurationFile.py
+++ b/onelogin_aws_cli/tests/test_configurationFile.py
@@ -88,13 +88,3 @@ subdomain = mock_subdomain
         cf = self._helper_build_config("""[section]
 first=foo""")
         self.assertTrue(cf.is_initialised)
-
-    def test_has_defaults(self):
-
-        content = StringIO()
-        cf = ConfigurationFile(content)
-        self.assertFalse(cf.has_defaults)
-
-        cf = self._helper_build_config("""[defaults]
-first=foo""")
-        self.assertTrue(cf.has_defaults)


### PR DESCRIPTION
We should not create a section when reading/writing only if it does not exist.

We should only create a section if we are trying to modify/write to the config file and the section does not exist.