### PR TITLE
Add better error handling

### DIFF
--- a/onelogin_aws_cli/cli.py
+++ b/onelogin_aws_cli/cli.py
@@ -3,6 +3,8 @@ Collections of entrypoints
 """
 import sys
 
+from os import environ
+
 from onelogin_aws_cli import DEFAULT_CONFIG_PATH, OneloginAWS
 from onelogin_aws_cli.argparse import OneLoginAWSArgumentParser
 from onelogin_aws_cli.configuration import ConfigurationFile
@@ -38,18 +40,26 @@ def login(args=sys.argv[1:]):
     :param args:
     """
 
-    cfg = ConfigurationFile()
-    parser = OneLoginAWSArgumentParser()
-    config_section, args = _load_config(parser, cfg, args)
+    debug = environ.get('ONELOGIN_AWS_CLI_DEBUG', '0') == '1'
+    try:
 
-    # Handle legacy `--renewSeconds` option while it is deprecated
-    if args.renew_seconds or args.renew_seconds_legacy:
-        print("ERROR: --renewSeconds  and --renew-seconds have been "
-              "deprecated due to longer AWS STS sessions.")
-        print("These options will be removed completely in a future version.")
-        sys.exit(1)
+        cfg = ConfigurationFile()
+        parser = OneLoginAWSArgumentParser()
+        config_section, args = _load_config(parser, cfg, args)
 
-    config_section.set_overrides(vars(args))
+        # Handle legacy `--renewSeconds` option while it is deprecated
+        if args.renew_seconds or args.renew_seconds_legacy:
+            print("ERROR: --renewSeconds  and --renew-seconds have been "
+                  "deprecated due to longer AWS STS sessions.")
+            print("These options will be removed completely in a future version.")
+            sys.exit(1)
 
-    api = OneloginAWS(config_section)
-    api.save_credentials()
+        config_section.set_overrides(vars(args))
+
+        api = OneloginAWS(config_section)
+        api.save_credentials()
+
+    except Exception as e:
+        if debug:
+            raise e
+        print(str(e))


### PR DESCRIPTION
Users don’t need to be presented with a full stack trace. The error itself in most cases is enough to provider information