### PR TITLE
Get all prompts to use user_choice

### DIFF
--- a/onelogin_aws_cli/credentials.py
+++ b/onelogin_aws_cli/credentials.py
@@ -9,6 +9,7 @@ import keyring
 from onelogin.api.models.device import Device
 
 from onelogin_aws_cli.configuration import Section
+from onelogin_aws_cli.userquery import user_choice
 
 
 class MFACredentials(object):
@@ -18,27 +19,17 @@ class MFACredentials(object):
     """
 
     def __init__(self):
-        self._device_index = None
-        self._devices = []
-        self._otp = None
-
         self.reset()
 
     @property
     def has_device(self) -> bool:
         """True if the MFA has an MFA device selected waiting to be used"""
-        return (self._device_index is not None) and \
-               (self._device_index < len(self._devices))
+        return self.device is not None
 
     @property
     def has_otp(self) -> bool:
         """True if the MFA has an OTP waiting to be used"""
         return self._otp is not None
-
-    @property
-    def device(self) -> Device:
-        """Return the device selected by the user"""
-        return self._devices[self._device_index]
 
     @property
     def otp(self) -> str:
@@ -58,7 +49,7 @@ class MFACredentials(object):
         """Remove all state from this class"""
 
         self._devices = []
-        self._device_index = None
+        self.device = None
 
         self._otp = None
 
@@ -67,18 +58,11 @@ class MFACredentials(object):
 
         self._devices = devices
 
-        if len(self._devices) > 1:
-
-            for i, device in enumerate(self._devices):
-                print("{i}. {device}".format(
-                    i=i + 1,
-                    device=device.type
-                ))
-
-            device_num = input("Which OTP Device? ")
-            self._device_index = int(device_num) - 1
-        else:
-            self._device_index = 0
+        self.device = user_choice(
+            'Pick an OTP Device:',
+            self._devices,
+            lambda d: d.type,
+        )
 
     def prompt_token(self):
         """Ask the user for an OTP token"""

--- a/onelogin_aws_cli/credentials.py
+++ b/onelogin_aws_cli/credentials.py
@@ -19,6 +19,10 @@ class MFACredentials(object):
     """
 
     def __init__(self):
+        self._devices = []
+        self.device = None
+        self._otp = None
+
         self.reset()
 
     @property

--- a/onelogin_aws_cli/tests/test_MFACredentials.py
+++ b/onelogin_aws_cli/tests/test_MFACredentials.py
@@ -16,14 +16,10 @@ class TestMFACredentials(TestCase):
     def test_has_device(self):
         self.assertFalse(self.mfa.has_device)
 
-        self.mfa._device_index = 1
-        self.assertFalse(self.mfa.has_device)
-
-        self.mfa._device_index = None
         self.mfa._devices = [Device(dict())]
         self.assertFalse(self.mfa.has_device)
 
-        self.mfa._device_index = 0
+        self.mfa.device = self.mfa._devices[0]
         self.assertTrue(self.mfa.has_device)
 
     def test_has_otp(self):
@@ -31,19 +27,6 @@ class TestMFACredentials(TestCase):
 
         self.mfa._otp = 23487
         self.assertTrue(self.mfa.has_otp)
-
-    def test_device(self):
-        with self.assertRaises(TypeError):
-            self.mfa.device
-
-        self.mfa._devices = [Device(dict(
-            device_id='mock_device_id'
-        ))]
-        self.mfa._device_index = 0
-
-        device = self.mfa.device
-
-        self.assertEqual(device.id, 'mock_device_id')
 
     def test_otp(self):
         self.assertIsNone(self.mfa.otp)
@@ -54,28 +37,28 @@ class TestMFACredentials(TestCase):
     def test_ready(self):
         self.assertFalse(self.mfa.ready())
 
-        self.mfa._device_index = 0
         self.mfa._devices = [Device(dict(
             device_id='mock_device_id'
         ))]
+        self.mfa.device = self.mfa._devices[0]
         self.mfa._otp = 23487
 
         self.assertTrue(self.mfa.ready())
 
     def test_reset(self):
-        self.mfa._device_index = 0
         self.mfa._devices = [Device(dict(
             device_id='mock_device_id'
         ))]
+        self.mfa.device = self.mfa._devices[0]
         self.mfa._otp = 23487
 
-        self.assertEqual(self.mfa._device_index, 0)
+        self.assertEqual(self.mfa.device.id, 'mock_device_id')
         self.assertEqual(self.mfa._devices[0].id, 'mock_device_id')
         self.assertEqual(self.mfa.otp, 23487)
 
         self.mfa.reset()
 
-        self.assertIsNone(self.mfa._device_index)
+        self.assertIsNone(self.mfa.device)
         self.assertListEqual(self.mfa._devices, [])
         self.assertIsNone(self.mfa.otp)
 
@@ -83,7 +66,6 @@ class TestMFACredentials(TestCase):
         self.mfa.select_device([
             Device(dict(device_id='1'))
         ])
-        self.assertEqual(self.mfa._device_index, 0)
         self.assertEqual(self.mfa.device.id, '1')
 
         with patch('builtins.input', side_effect=['3']):

--- a/onelogin_aws_cli/tests/test_userquery.py
+++ b/onelogin_aws_cli/tests/test_userquery.py
@@ -31,6 +31,14 @@ class TestUser_choice(TestCase):
         assert result == "world"
         assert "Invalid option" in output
 
+    def test_user_choice_no_options(self):
+        with self.assertRaises(Exception):
+            user_choice('one', [])
+
+    def test_user_choice_one_option(self):
+        result = user_choice('one', ['foo'])
+        self.assertEqual('foo', result)
+
     def test_user_role_prompt(self):
         mock_stdout = StringIO()
 
@@ -43,7 +51,15 @@ class TestUser_choice(TestCase):
                 ])
 
         self.assertEqual(('mock_role2', 'mock_principal_2'), selected_role)
-        self.assertEqual("""[1] mock_role1
+        self.assertEqual("""Pick a role:
+[1] mock_role1
 [2] mock_role2
 [3] mock_role3
 """, mock_stdout.getvalue())
+
+    def test_user_role_prompt_one_option(self):
+        selected_role = user_role_prompt([
+            ('mock_role1', 'mock_principal_1'),
+        ])
+
+        self.assertEqual(('mock_role1', 'mock_principal_1'), selected_role)

--- a/onelogin_aws_cli/userquery.py
+++ b/onelogin_aws_cli/userquery.py
@@ -1,12 +1,14 @@
 """
 Interactions with the user through the cli
 """
-from typing import List, Tuple
+from typing import Any, Callable, List, Tuple
 
 RolePrincipalPair = Tuple
 
 
-def user_choice(question: str, options: List, renderer=lambda x: x):
+def user_choice(question: str,
+                options: List[Any],
+                renderer: Callable[[Any], str]=lambda x: x):
     """
     Prompt a user with a question and a specific set of possible responses
     :param question: Specifying context for the user to select an option

--- a/onelogin_aws_cli/userquery.py
+++ b/onelogin_aws_cli/userquery.py
@@ -6,19 +6,24 @@ from typing import List, Tuple
 RolePrincipalPair = Tuple
 
 
-def user_choice(question: str, options: List[str]) -> str:
+def user_choice(question: str, options: List, renderer=lambda x: x):
     """
     Prompt a user with a question and a specific set of possible responses
     :param question: Specifying context for the user to select an option
     :param options: A list of options for the user to select from
     """
-    print(question + "\n")
-    option_list = ""
+    if len(options) == 1:
+        return options[0]
+
+    print(question)
+    if len(options) == 0:
+        raise Exception("No options found")
+    option_list = []
     for i, option in enumerate(options):
-        option_list += ("{}. {}\n".format(i + 1, option))
+        option_list.append("[{}] {}".format(i + 1, renderer(option)))
     selection = None
     while selection is None:
-        print(option_list)
+        print("\n".join(option_list))
         choice = input("? ")
         try:
             val = int(choice) - 1
@@ -36,20 +41,8 @@ def user_role_prompt(all_roles: List[RolePrincipalPair]) -> RolePrincipalPair:
     Prompt a user with a list of AWS IAM roles to choose from. If only 1 role
     is available, return that.
     """
-    selected_role = None
-
-    if len(all_roles) > 1:
-        ind = 0
-        for role, principal in all_roles:
-            print("[{}] {}".format(ind + 1, role))
-            ind += 1
-        while selected_role is None:
-            choice = int(input("Role Number: ")) - 1
-            if choice in range(len(all_roles)):
-                selected_role = choice
-            else:
-                print("Invalid role index, please try again")
-    else:
-        selected_role = 0
-
-    return all_roles[selected_role]
+    return user_choice(
+        "Pick a role:",
+        all_roles,
+        renderer=lambda role: role[0],
+    )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
In preparation for being able to save prompt selections, this moves more of the prompts to use user_choice.  The function is extended to allow custom renderers, and adds the behavior we have in most prompts (e.g., automatic selection if only one option is available); this way we can kill a bunch of redundant code.

This also simplifies the way we store the current device somewhat.

<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Doesn't directly resolve any issues, but will handle #62 and #82 eventually.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
See above

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unittests

## Screenshots (if appropriate):
