### PR TITLE
Initialised should return true if defaults is non-empty

### DIFF
--- a/onelogin_aws_cli/cli.py
+++ b/onelogin_aws_cli/cli.py
@@ -21,12 +21,17 @@ def _load_config(parser, config_file: ConfigurationFile, args=sys.argv[1:]):
 
     config_section = config_file.section(cli_args.config_name)
 
-    if config_section is None:
+    if config_section is None and cli_args.config_name:
         sys.exit(
             "Configuration '{}' not defined. "
             "Please run 'onelogin-aws-login -c'".format(
                 cli_args.config_name
             )
+        )
+    elif config_section is None:
+        sys.exit(
+            "No default configuration section found. "
+            "Please run 'onelogin-aws-login -c"
         )
 
     return config_section, cli_args

--- a/onelogin_aws_cli/cli.py
+++ b/onelogin_aws_cli/cli.py
@@ -23,17 +23,12 @@ def _load_config(parser, config_file: ConfigurationFile, args=sys.argv[1:]):
 
     config_section = config_file.section(cli_args.config_name)
 
-    if config_section is None and cli_args.config_name:
+    if config_section is None:
         sys.exit(
             "Configuration '{}' not defined. "
             "Please run 'onelogin-aws-login -c'".format(
                 cli_args.config_name
             )
-        )
-    elif config_section is None:
-        sys.exit(
-            "No default configuration section found. "
-            "Please run 'onelogin-aws-login -c"
         )
 
     return config_section, cli_args

--- a/onelogin_aws_cli/configuration.py
+++ b/onelogin_aws_cli/configuration.py
@@ -24,13 +24,13 @@ class ConfigurationFile(configparser.ConfigParser):
 
     @property
     def has_defaults(self) -> bool:
-        """True if the defaults section has settings beyond our defaults"""
-        return len(self[self.default_section]) > len(self.DEFAULTS)
+        """True if the default section is non-empty"""
+        return len(self.items(self.default_section)) > 0
 
     @property
     def is_initialised(self) -> bool:
         """True if there is at least one section"""
-        return (len(self.sections()) > 0)
+        return (len(self.sections()) > 0) or self.has_defaults
 
     def load(self):
         self.read_file(self.file)

--- a/onelogin_aws_cli/configuration.py
+++ b/onelogin_aws_cli/configuration.py
@@ -34,13 +34,6 @@ class ConfigurationFile(configparser.ConfigParser):
 
     def load(self):
         self.read_file(self.file)
-        # For backwards compatibility, we check if they have a default
-        # section instead of a defaults section and do a little switcheroo as
-        # needed.
-        if self.has_section('default') and not self.has_defaults:
-            print("It looks like you're using a the deprecated 'default' "
-                  "section.\nConsider renaming the section to 'defaults'.")
-            self.default_section = 'default'
 
     def initialise(self, config_name='defaults'):
         """

--- a/onelogin_aws_cli/configuration.py
+++ b/onelogin_aws_cli/configuration.py
@@ -12,7 +12,7 @@ class ConfigurationFile(configparser.ConfigParser):
     def __init__(self, config_file=None):
         super().__init__(default_section='defaults')
 
-        self[self.default_section] = self.DEFAULTS
+        self[self.default_section] = dict(self.DEFAULTS)
 
         self.file = config_file
 

--- a/onelogin_aws_cli/configuration.py
+++ b/onelogin_aws_cli/configuration.py
@@ -22,7 +22,7 @@ class ConfigurationFile(configparser.ConfigParser):
     @property
     def has_defaults(self) -> bool:
         """True if the defaults section has settings beyond our defaults"""
-        return len(self.defaults()) > len(self.DEFAULTS)
+        return len(self[self.default_section]) > len(self.DEFAULTS)
 
     @property
     def is_initialised(self) -> bool:

--- a/onelogin_aws_cli/configuration.py
+++ b/onelogin_aws_cli/configuration.py
@@ -48,9 +48,6 @@ class ConfigurationFile(configparser.ConfigParser):
         onelogin-aws-cli config file
         """
         print("Configure Onelogin and AWS\n\n")
-        if not config_name:
-            config_name = self.default_section
-
         config_section = self.section(config_name)
         if config_section is None:
             self.add_section(config_name)

--- a/onelogin_aws_cli/tests/test_configurationFile.py
+++ b/onelogin_aws_cli/tests/test_configurationFile.py
@@ -118,10 +118,6 @@ first=foo""")
 first=foo""")
         self.assertEqual("defaults", cf.default_section)
 
-        cf = self._helper_build_config("""[default]
-second=bar""")
-        self.assertEqual("default", cf.default_section)
-
         cf = self._helper_build_config("""[defaults]
 first=foo
 

--- a/onelogin_aws_cli/tests/test_configurationFile.py
+++ b/onelogin_aws_cli/tests/test_configurationFile.py
@@ -117,16 +117,15 @@ first=foo""")
 
         cf = self._helper_build_config("""[defaults]
 first=foo""")
-        self.assertIn("first", cf.defaults())
+        self.assertEqual("defaults", cf.default_section)
 
         cf = self._helper_build_config("""[default]
 second=bar""")
-        self.assertIn("second", cf.defaults())
+        self.assertEqual("default", cf.default_section)
 
         cf = self._helper_build_config("""[defaults]
 first=foo
 
 [default]
 second=bar""")
-        self.assertIn("first", cf.defaults())
-        self.assertNotIn("second", cf.defaults())
+        self.assertEqual("defaults", cf.default_section)

--- a/onelogin_aws_cli/tests/test_configurationFile.py
+++ b/onelogin_aws_cli/tests/test_configurationFile.py
@@ -63,12 +63,12 @@ save_password = true
     def test_can_save_password_username_defaults_false(self):
         cfg = self._helper_build_config("""[defaults]
 save_password = false""")
-        self.assertFalse(cfg.section(None).can_save_password)
+        self.assertFalse(cfg.section("defaults").can_save_password)
 
     def test_can_save_password_username_defaults_true(self):
         cfg = self._helper_build_config("""[defaults]
 save_password = true""")
-        self.assertTrue(cfg.section(None).can_save_password)
+        self.assertTrue(cfg.section("defaults").can_save_password)
 
     def test_initialise(self):
         str = StringIO()

--- a/onelogin_aws_cli/tests/test_configurationFile.py
+++ b/onelogin_aws_cli/tests/test_configurationFile.py
@@ -60,6 +60,16 @@ save_password = true
 [profile_test]""")
         self.assertTrue(cfg.section("profile_test").can_save_password)
 
+    def test_can_save_password_username_defaults_false(self):
+        cfg = self._helper_build_config("""[defaults]
+save_password = false""")
+        self.assertFalse(cfg.section(None).can_save_password)
+
+    def test_can_save_password_username_defaults_true(self):
+        cfg = self._helper_build_config("""[defaults]
+save_password = true""")
+        self.assertTrue(cfg.section(None).can_save_password)
+
     def test_initialise(self):
         str = StringIO()
         cfg = ConfigurationFile(str)
@@ -71,8 +81,6 @@ save_password = true
 
         self.assertEqual("""[defaults]
 save_password = False
-
-[default]
 base_uri = https://api.eu.onelogin.com/
 client_id = mock_client_id
 client_secret = mock_client_secret
@@ -90,3 +98,35 @@ subdomain = mock_subdomain
         cf = self._helper_build_config("""[section]
 first=foo""")
         self.assertTrue(cf.is_initialised)
+
+        cf = self._helper_build_config("""[defaults]
+first=foo""")
+        self.assertTrue(cf.is_initialised)
+
+    def test_has_defaults(self):
+
+        content = StringIO()
+        cf = ConfigurationFile(content)
+        self.assertFalse(cf.has_defaults)
+
+        cf = self._helper_build_config("""[defaults]
+first=foo""")
+        self.assertTrue(cf.has_defaults)
+
+    def test_supports_default(self):
+
+        cf = self._helper_build_config("""[defaults]
+first=foo""")
+        self.assertIn("first", cf.defaults())
+
+        cf = self._helper_build_config("""[default]
+second=bar""")
+        self.assertIn("second", cf.defaults())
+
+        cf = self._helper_build_config("""[defaults]
+first=foo
+
+[default]
+second=bar""")
+        self.assertIn("first", cf.defaults())
+        self.assertNotIn("second", cf.defaults())


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Currently, initialised only checks if you have a non-empty non-default section.  This means that after running `-c` `is_initialised` will still return false.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The current behavior may lead to confusion if prompted to initialise their config when it's already been initialised.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
New test coverage.