### PR TITLE
Ability to save roles and token device types

### DIFF
--- a/onelogin_aws_cli/__init__.py
+++ b/onelogin_aws_cli/__init__.py
@@ -31,7 +31,7 @@ class OneloginAWS(object):
         self.credentials = None
         self.duration_seconds = int(config['duration_seconds'])
         self.user_credentials = UserCredentials(config)
-        self.mfa = MFACredentials()
+        self.mfa = MFACredentials(config)
 
         base_uri_parts = self.config['base_uri'].split('.')
         self.ol_client = OneLoginClient(
@@ -113,7 +113,10 @@ class OneloginAWS(object):
         # If I have more than one role, ask the user which one they want,
         # otherwise just proceed
 
-        self.role_arn, self.principal_arn = user_role_prompt(self.all_roles)
+        self.role_arn, self.principal_arn = user_role_prompt(
+            self.all_roles,
+            saved_choice=self.config.get("role_arn"),
+        )
 
     def assume_role(self):
         """Perform an AWS SAML role assumption"""

--- a/onelogin_aws_cli/configuration.py
+++ b/onelogin_aws_cli/configuration.py
@@ -120,3 +120,8 @@ class Section(object):
 
     def __contains__(self, item):
         return self.config.has_option(self.section_name, item)
+
+    def get(self, item, default=None):
+        if item in self:
+            return self[item]
+        return default

--- a/onelogin_aws_cli/credentials.py
+++ b/onelogin_aws_cli/credentials.py
@@ -18,10 +18,11 @@ class MFACredentials(object):
     retrieving of OTP's
     """
 
-    def __init__(self):
+    def __init__(self, config: Section):
         self._devices = []
         self.device = None
         self._otp = None
+        self._config = config
 
         self.reset()
 
@@ -65,7 +66,8 @@ class MFACredentials(object):
         self.device = user_choice(
             'Pick an OTP Device:',
             self._devices,
-            lambda d: d.type,
+            renderer=lambda d: d.type,
+            saved_choice=self._config.get("otp_device"),
         )
 
     def prompt_token(self):

--- a/onelogin_aws_cli/tests/test_configurationFile.py
+++ b/onelogin_aws_cli/tests/test_configurationFile.py
@@ -87,3 +87,13 @@ subdomain = mock_subdomain
         cf = self._helper_build_config("""[section]
 first=foo""")
         self.assertTrue(cf.is_initialised)
+
+    def test_section_get(self):
+        cfg = self._helper_build_config("""[profile_test]
+save_password = true""")
+        self.assertTrue(cfg.section("profile_test").get("save_password"))
+
+    def test_section_get_fallback(self):
+        cfg = self._helper_build_config("""[profile_test]
+""")
+        self.assertIsNone(cfg.section("profile_test").get("save_password"))

--- a/onelogin_aws_cli/tests/test_oneloginAWS_saml.py
+++ b/onelogin_aws_cli/tests/test_oneloginAWS_saml.py
@@ -13,6 +13,11 @@ class _MockSection(Namespace):
     def __getitem__(self, item):
         return self.__getattribute__(item)
 
+    def get(self, item):
+        if hasattr(self, item):
+            return self[item]
+        return None
+
 
 class TestOneloginSAML(TestCase):
     def setUp(self):

--- a/onelogin_aws_cli/tests/test_userquery.py
+++ b/onelogin_aws_cli/tests/test_userquery.py
@@ -39,6 +39,22 @@ class TestUser_choice(TestCase):
         result = user_choice('one', ['foo'])
         self.assertEqual('foo', result)
 
+    def test_user_choice_preselected(self):
+        result = user_choice('one', ['foo', 'bar'], saved_choice='bar')
+        self.assertEqual('bar', result)
+
+    def test_user_choice_bad_preselected(self):
+        mock_stdout = StringIO()
+
+        with patch('builtins.input', side_effect=['2']):
+            with contextlib.redirect_stdout(mock_stdout):
+                result = user_choice('one', ['foo', 'bar'], saved_choice='baz')
+
+        output = mock_stdout.getvalue()
+        assert result == "bar"
+        assert "Invalid option" not in output
+        assert "Ignoring invalid saved choice" in output
+
     def test_user_role_prompt(self):
         mock_stdout = StringIO()
 

--- a/onelogin_aws_cli/userquery.py
+++ b/onelogin_aws_cli/userquery.py
@@ -8,12 +8,19 @@ RolePrincipalPair = Tuple
 
 def user_choice(question: str,
                 options: List[Any],
-                renderer: Callable[[Any], str]=lambda x: x):
+                renderer: Callable[[Any], str]=lambda x: x,
+                saved_choice: str=None):
     """
     Prompt a user with a question and a specific set of possible responses
     :param question: Specifying context for the user to select an option
     :param options: A list of options for the user to select from
     """
+    if saved_choice:
+        for option in options:
+            if renderer(option) == saved_choice:
+                return option
+        print("Ignoring invalid saved choice '{}'".format(saved_choice))
+
     if len(options) == 1:
         return options[0]
 
@@ -38,7 +45,8 @@ def user_choice(question: str,
     return selection
 
 
-def user_role_prompt(all_roles: List[RolePrincipalPair]) -> RolePrincipalPair:
+def user_role_prompt(all_roles: List[RolePrincipalPair],
+                     saved_choice: str=None) -> RolePrincipalPair:
     """
     Prompt a user with a list of AWS IAM roles to choose from. If only 1 role
     is available, return that.
@@ -47,4 +55,5 @@ def user_role_prompt(all_roles: List[RolePrincipalPair]) -> RolePrincipalPair:
         "Pick a role:",
         all_roles,
         renderer=lambda role: role[0],
+        saved_choice=saved_choice,
     )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
* Update the user choice code to accept a selected option as a parameter.  It does some checking against the existing option list and returns it when appropriate.
* Add a `get` method to sections to make getting optional settings a bit more ergonomic.
* Wire this up to the role and otp user choice call sites.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#82 #62 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
For some users, multiple roles and otp devices associated with their account may make this app more cumbersome to use; especially if they end up selecting the same option each time.  This will allow users to update their config to skip those prompts.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
See expanded unittests.