### PR TITLE
Handle unspecified username

### DIFF
--- a/onelogin_aws_cli/credentials.py
+++ b/onelogin_aws_cli/credentials.py
@@ -83,7 +83,7 @@ class UserCredentials(object):
     SERVICE_NAME = "onelogin-aws-cli"
 
     def __init__(self, config: Section):
-        self.username = config['username']
+        self.username = config.get('username')
         self.configuration = config
 
         # This is `None`, as the password should be be emitted from this class

--- a/onelogin_aws_cli/tests/test_oneloginAWS_saml.py
+++ b/onelogin_aws_cli/tests/test_oneloginAWS_saml.py
@@ -112,6 +112,20 @@ class TestOneloginSAML(TestCase):
         self.assertEqual(self.ol.user_credentials.username, 'mock-username')
         self.assertEqual(self.ol.user_credentials.password, 'mock-password')
 
+    def test_username_unspecified(self):
+        ol = OneloginAWS(
+            _MockSection(
+                base_uri="https://api.us.onelogin.com/",
+                client_id='mock-id',
+                client_secret='mock-secret',
+                aws_app_id='mock-app-id',
+                subdomain='example',
+                can_save_password=False,
+                duration_seconds=2600
+            ),
+        )
+        self.assertIsNone(ol.user_credentials.username)
+
     def tearDown(self):
         """
         Reset MagicMocks


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Currently we unconditionally attempt to retrieve the username from the config; however we do so in a way that will throw a KeyError if the username is not actually in the config file.  This PR makes us a bit more careful.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#101 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unittest
