### PR TITLE
Fix config initialization

### DIFF
--- a/onelogin_aws_cli/cli.py
+++ b/onelogin_aws_cli/cli.py
@@ -18,12 +18,12 @@ def _load_config(parser, config_file: ConfigurationFile, args=sys.argv[1:]):
         config_file.file = fp
         config_file.load()
 
-    if (cli_args.configure or not config_file.is_initialised):
-        config_file.initialise(cli_args.config_name)
+        if (cli_args.configure or not config_file.is_initialised):
+            config_file.initialise(cli_args.config_name)
 
     config_section = config_file.section(cli_args.config_name)
 
-    if config_section is None:
+    if config_section is None or not config_section.has_required:
         sys.exit(
             "Configuration '{}' not defined. "
             "Please run 'onelogin-aws-login -c'".format(

--- a/onelogin_aws_cli/configuration.py
+++ b/onelogin_aws_cli/configuration.py
@@ -77,7 +77,7 @@ class ConfigurationFile(configparser.ConfigParser):
     def save(self):
         """Save this config to disk"""
         self.write(self.file)
-        print("Configuration written to '{}'".format(self.file))
+        print("Configuration written to '{}'".format(self.file.name))
 
     def section(self, section_name: str):
         """

--- a/onelogin_aws_cli/configuration.py
+++ b/onelogin_aws_cli/configuration.py
@@ -77,7 +77,9 @@ class ConfigurationFile(configparser.ConfigParser):
     def save(self):
         """Save this config to disk"""
         self.write(self.file)
-        print("Configuration written to '{}'".format(self.file.name))
+        print("Configuration written to '{}'".format(
+            self.file.name if hasattr(self.file, 'name') else self.file,
+        ))
 
     def section(self, section_name: str):
         """

--- a/onelogin_aws_cli/configuration.py
+++ b/onelogin_aws_cli/configuration.py
@@ -12,6 +12,14 @@ class ConfigurationFile(configparser.ConfigParser):
         duration_seconds=3600
     )
 
+    REQUIRED = [
+        'base_uri',
+        'client_id',
+        'client_secret',
+        'aws_app_id',
+        'subdomain',
+    ]
+
     def __init__(self, config_file=None):
         super().__init__(
             default_section='defaults',
@@ -93,6 +101,16 @@ class Section(object):
         self.config = config
         self.section_name = section_name
         self._overrides = {}
+
+    @property
+    def has_required(self) -> bool:
+        """
+        Returns true if the section (including the defaults fallback)
+        contains all the required keys.
+        """
+        return all([
+            self.__contains__(item) for item in ConfigurationFile.REQUIRED
+        ])
 
     @property
     def can_save_password(self) -> bool:

--- a/onelogin_aws_cli/tests/test_section.py
+++ b/onelogin_aws_cli/tests/test_section.py
@@ -32,3 +32,17 @@ class TestSection(TestCase):
         ))
 
         self.assertEqual(sec['foo'], 'bar')
+
+    def test_has_required_false(self):
+        sec = Section('mock-section', MagicMock(
+            has_option=MagicMock(side_effect=lambda s, x: x != 'base_uri')
+        ))
+
+        self.assertFalse(sec.has_required)
+
+    def test_has_required_true(self):
+        sec = Section('mock-section', MagicMock(
+            has_option=MagicMock(return_value=True)
+        ))
+
+        self.assertTrue(sec.has_required)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Currently the initialization phase takes place outside of the `with` statement which means the saving will occur on a file handle that is already closed.  This PR fixes that issue.

This PR also fixes places where we expect an "initialised" config to contain certain fields.  This introduces a `has_required` property so that we can detect janky config cases and ask them to re-run the initialization process.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fixes #105 
Also improves error handling for #84 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added a few unittests.
Also ran from the command line as described in the issue.