### PR TITLE
Added information about MFA configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ other sections.
 - `role_arn` - AWS Role ARN to assume after authenticating against OneLogin.  
   Specifying this will disable the display of available roles and the
   interactive choice to select a role after authenticating.
+- `otp_device` - Allow the automatic selection of an OTP device. This value is the human readable string name for the device. Eg, `OneLogin Protect`, `Yubico YubiKey`, etc
 
 ### Example
 


### PR DESCRIPTION
Added implementation notes about the MFA device.

## Description
It is not self evident that the `otp_device` directive exists, or how to configure it. This PR adds documentation on the type of value for the `otp_device` directive.

## Motivation and Context
This functionality is not documented and should be.

## How Has This Been Tested?
This is a change to documentation, so no breaking changes exist.