### PR TITLE
Support for getting IP address, to support IP whitelist in OneLogin Policies

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,10 @@ other sections.
 - `role_arn` - AWS Role ARN to assume after authenticating against OneLogin.  
   Specifying this will disable the display of available roles and the
   interactive choice to select a role after authenticating.
+- `ip_address` - An IP address to send to OneLogin.
+  Relevant when using OneLogin Policies with an IP whitelist.
+- `ip_address_api_uri` - An API endpoint that returns the current IP over HTTP.
+  Relevant when using OneLogin Policies with an IP whitelist.
 
 ### Example
 

--- a/onelogin_aws_cli/__init__.py
+++ b/onelogin_aws_cli/__init__.py
@@ -80,6 +80,12 @@ class OneloginAWS(object):
         self.saml = saml_resp
 
     def get_ip_address(self):
+        # if ip address has been hard coded in config file, use that
+        ip_address = self.config.get('ip_address')
+        if ip_address is not None:
+            return ip_address
+
+        # otherwise get ip address dynamically from api
         uri = self.config.get('ip_address_api_uri')
 
         # if option has not been configured

--- a/onelogin_aws_cli/__init__.py
+++ b/onelogin_aws_cli/__init__.py
@@ -6,6 +6,8 @@ import xml.etree.ElementTree as ElementTree
 import base64
 import boto3
 import os
+import urllib
+
 from onelogin.api.client import OneLoginClient
 
 from onelogin_aws_cli.configuration import Section
@@ -49,10 +51,11 @@ class OneloginAWS(object):
         self.user_credentials.load_credentials()
 
         saml_resp = self.ol_client.get_saml_assertion(
-            self.user_credentials.username,
-            self.user_credentials.password,
-            self.config['aws_app_id'],
-            self.config['subdomain']
+            username_or_email=self.user_credentials.username,
+            password=self.user_credentials.password,
+            app_id=self.config['aws_app_id'],
+            subdomain=self.config['subdomain'],
+            ip_address=self.get_ip_address(),
         )
 
         if saml_resp is None:
@@ -60,6 +63,7 @@ class OneloginAWS(object):
                 error=self.ol_client.error,
                 desc=self.ol_client.error_description
             ))
+
         if saml_resp.mfa:
             if not self.mfa.ready():
                 self.mfa.select_device(saml_resp.mfa.devices)
@@ -74,6 +78,20 @@ class OneloginAWS(object):
             )
 
         self.saml = saml_resp
+
+    def get_ip_address(self):
+        uri = self.config.get('ip_address_api_uri')
+
+        # if option has not been configured
+        if uri is None:
+            return None
+
+        # fetch ip from the uri
+        request = urllib.request.Request(uri)
+        with urllib.request.urlopen(request) as response:
+            data = response.read()
+            ip_address = data.decode('utf-8')
+            return ip_address
 
     def get_arns(self):
         """Extract the IAM Role ARNs from the SAML Assertion"""


### PR DESCRIPTION
## Description
Allows to configure an IP address or an API URI to fetch IP address from.

## Motivation and Context
We use whitelist rules to say that users don't have to use MFA when coming from a certain IP. This is supported in OneLogin already. Let's enable support for it in this program too.

## How Has This Been Tested?
Configure IP whitelist in a Policy in OneLogin.

Add either one of these to config file.

```
ip_address = 1.2.3.4
```

```
ip_address_api_uri = https://api.ipify.org
```
