### PR TITLE
Feature/remove renew seconds

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,9 +78,6 @@ Use aws cli with --profile 772123451421:role/onelogin-test-s3/myuser@mycompany.c
   [configuration file](#configuration-file).
 - `ONELOGIN_AWS_CLI_DURATION_SECONDS` - See the corresponding value in the
   [configuration file](#configuration-file).
-- `ONELOGIN_AWS_CLI_RENEW_SECONDS` - See the corresponding value in the
-  [configuration file](#configuration-file).
-
 
 
 ## Configuration File
@@ -115,8 +112,7 @@ other sections.
   This refers to an AWS CLI profile name defined in your `~./aws/config` file.
 - `duration_seconds` - Length of the IAM STS session in seconds.  
   This cannot exceed the maximum duration specified in AWS for the given role.
-- `renew_seconds` - How often to re-authenticate the session in seconds.
-- `aws_app_id` - ID of the AWS App instance in your OneLogin account.  
+- `aws_app_id` - ID of the AWS App instance in your OneLogin account.
   This ID can be found by logging in to your OneLogin web dashboard
   and navigating to `Administration` -> `APPS` -> `<Your app instance>`,
   and copying it from the URL in the address bar.
@@ -139,7 +135,6 @@ client_secret = a85234b6db01a29a493e2422d7930dffe6f4d3a826270a18838574f6b8ef7c3e
 save_password = yes
 profile = mycompany-onelogin
 duration_seconds = 3600
-renew_seconds = 60
 
 [testing]
 aws_app_id = 555029

--- a/onelogin_aws_cli/argparse.py
+++ b/onelogin_aws_cli/argparse.py
@@ -48,23 +48,6 @@ class OneLoginAWSArgumentParser(argparse.ArgumentParser):
             version="%(prog)s " + version
         )
 
-        renew_seconds_group = self.add_mutually_exclusive_group()
-
-        renew_seconds_group.add_argument(
-            '-r', '--renew-seconds', type=int,
-            action=EnvDefault, required=False,
-            help='Auto-renew credentials after this many seconds'
-        )
-
-        renew_seconds_group.add_argument(
-            # Help is suppressed as this is replaced by the POSIX friendlier
-            # version above. This is here for legacy compliance and will
-            # be deprecated.
-            '--renewSeconds', type=int, help=argparse.SUPPRESS,
-            action=EnvDefault, required=False,
-            dest='renew_seconds_legacy'
-        )
-
         self.add_argument(
             '-c', '--configure', dest='configure', action='store_true',
             help='Configure OneLogin and AWS settings', default=False

--- a/onelogin_aws_cli/cli.py
+++ b/onelogin_aws_cli/cli.py
@@ -47,14 +47,6 @@ def login(args=sys.argv[1:]):
         parser = OneLoginAWSArgumentParser()
         config_section, args = _load_config(parser, cfg, args)
 
-        # Handle legacy `--renewSeconds` option while it is deprecated
-        if args.renew_seconds or args.renew_seconds_legacy:
-            print("ERROR: --renewSeconds  and --renew-seconds have been "
-                  "deprecated due to longer AWS STS sessions.")
-            print("These options will be removed completely in "
-                  "a future version.")
-            sys.exit(1)
-
         config_section.set_overrides(vars(args))
 
         api = OneloginAWS(config_section)

--- a/onelogin_aws_cli/tests/test_oneLoginAWSArgumentParser.py
+++ b/onelogin_aws_cli/tests/test_oneLoginAWSArgumentParser.py
@@ -50,7 +50,6 @@ class TestOneLoginAWSArgumentParser(TestCase):
             '-C', 'my_config',
             '--profile', 'my_profile',
             '-u', 'my_username',
-            '--renew-seconds', '30',
             '-c',
             '-d', '43200',
         ])
@@ -58,32 +57,15 @@ class TestOneLoginAWSArgumentParser(TestCase):
         self.assertEqual(args.config_name, 'my_config')
         self.assertEqual(args.profile, 'my_profile')
         self.assertEqual(args.username, 'my_username')
-        self.assertEqual(args.renew_seconds, 30)
         self.assertTrue(args.configure)
         self.assertEqual(args.duration_seconds, 43200)
 
-    def test_legacy_renew_seconds(self):
-        parser = OneLoginAWSArgumentParser()
-        args = parser.parse_args([
-            '--renewSeconds', '30'
-        ])
-
-        self.assertEqual(args.renew_seconds_legacy, 30)
-
-        with self.assertRaises(SystemExit) as cm:
-            parser.parse_args([
-                '--renewSeconds', '30',
-                '--renew-seconds', '30',
-            ])
-
-        self.assertEqual(cm.exception.code, 2)
 
     def test_environment_variable(self):
         environ['ONELOGIN_AWS_CLI_CONFIG_NAME'] = 'mock-config'
         environ['ONELOGIN_AWS_CLI_PROFILE'] = 'mock-profile'
         environ['ONELOGIN_AWS_CLI_USERNAME'] = 'mock-username'
         environ['ONELOGIN_AWS_CLI_DURATION_SECONDS'] = '10'
-        environ['ONELOGIN_AWS_CLI_RENEW_SECONDS'] = '10'
 
         parser = OneLoginAWSArgumentParser()
 
@@ -92,11 +74,9 @@ class TestOneLoginAWSArgumentParser(TestCase):
         self.assertEqual('mock-config', args.config_name)
         self.assertEqual('mock-profile', args.profile)
         self.assertEqual('mock-username', args.username)
-        self.assertEqual(10, args.renew_seconds)
         self.assertEqual(10, args.duration_seconds)
 
         del environ['ONELOGIN_AWS_CLI_CONFIG_NAME']
         del environ['ONELOGIN_AWS_CLI_PROFILE']
         del environ['ONELOGIN_AWS_CLI_USERNAME']
         del environ['ONELOGIN_AWS_CLI_DURATION_SECONDS']
-        del environ['ONELOGIN_AWS_CLI_RENEW_SECONDS']


### PR DESCRIPTION
Removed `--renew-seconds` option

## Description
The `--renew-seconds` option was needed before the advent of 12 hour sessions in AWS for SAML federated roles. As we now have 12 hour sessions, we no longer have to refresh the session every hour and have made this function redundant. It was deprecated in the past, and is now removed from the code base.

## Related Issue
 - https://github.com/physera/onelogin-aws-cli/pull/80

## Motivation and Context
This change is to remove code from the code base which is no longer functional. There have 2 version releases since the functionality was deprecated, which seems like a reasonable time allow for change of code for users.

## How Has This Been Tested?
Test cases pass, and have been modified to no longer make reference to renew-seconds options
