### PR TITLE
Support for specifying client IP address, or automatically getting it from ipify

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -9,6 +9,7 @@ verify_ssl = true
 "boto3" = "*"
 onelogin = "*"
 keyring = "*"
+ipify = "*"
 
 [requires]
 python_version = ">=3.5"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "f3852d21c16185eff6cb6615ec023912ac6549e88c2857a883e877a996b6494d"
+            "sha256": "aa272778bcb2111440dbd8d9051b7cf8fc75110bc2f35a678fffa5975aad708a"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -16,20 +16,33 @@
         ]
     },
     "default": {
+        "asn1crypto": {
+            "hashes": [
+                "sha256:2f1adbb7546ed199e3c90ef23ec95c5cf3585bac7d11fb7eb562a3fe89c64e87",
+                "sha256:9d5c20441baf0cb60a4ac34cc447c6c189024b6b4c6cd7877034f4965c464e49"
+            ],
+            "version": "==0.24.0"
+        },
+        "backoff": {
+            "hashes": [
+                "sha256:c1402291d7faca70ac3f2f7241e8942eb527f94945c7b2293030cfb6ce5a7805"
+            ],
+            "version": "==1.5.0"
+        },
         "boto3": {
             "hashes": [
-                "sha256:a2d5c0a007ff50b4a08f402925495e18e41e336d22767a2b4fa21913fa875b2f",
-                "sha256:f303b0feaabbe98b36ab12be1c641799104c935c9e0c9315b6fe53a39d668d79"
+                "sha256:b56b171d81c3dcf63821597439b965b57417744194fea97f2db0cc9481d90ed7",
+                "sha256:f1b6313cbffff2da2b34f98460c121fb45d2ae70124c6e25ee6f824975c6992c"
             ],
             "index": "pypi",
-            "version": "==1.7.14"
+            "version": "==1.7.27"
         },
         "botocore": {
             "hashes": [
-                "sha256:2d83993e60ba56ca3ddb48a0d4da86c1cfa1f687993abe760eeb0059d10e52f6",
-                "sha256:5e61efeb68688149fb8220f0bca6c8a89bc998dffb99673d0bf24cfe2f2e47a9"
+                "sha256:0e6d8c8156f85869efb3af9c888d235cfae5790908445cbb1af92367776baf22",
+                "sha256:e7c7d2ff2d36572ea7dfa5b5e5144e662c3973fbcc7ad33824491e508d07dc92"
             ],
-            "version": "==1.10.14"
+            "version": "==1.10.27"
         },
         "certifi": {
             "hashes": [
@@ -38,12 +51,67 @@
             ],
             "version": "==2018.4.16"
         },
+        "cffi": {
+            "hashes": [
+                "sha256:151b7eefd035c56b2b2e1eb9963c90c6302dc15fbd8c1c0a83a163ff2c7d7743",
+                "sha256:1553d1e99f035ace1c0544050622b7bc963374a00c467edafac50ad7bd276aef",
+                "sha256:1b0493c091a1898f1136e3f4f991a784437fac3673780ff9de3bcf46c80b6b50",
+                "sha256:2ba8a45822b7aee805ab49abfe7eec16b90587f7f26df20c71dd89e45a97076f",
+                "sha256:3c85641778460581c42924384f5e68076d724ceac0f267d66c757f7535069c93",
+                "sha256:3eb6434197633b7748cea30bf0ba9f66727cdce45117a712b29a443943733257",
+                "sha256:4c91af6e967c2015729d3e69c2e51d92f9898c330d6a851bf8f121236f3defd3",
+                "sha256:770f3782b31f50b68627e22f91cb182c48c47c02eb405fd689472aa7b7aa16dc",
+                "sha256:79f9b6f7c46ae1f8ded75f68cf8ad50e5729ed4d590c74840471fc2823457d04",
+                "sha256:7a33145e04d44ce95bcd71e522b478d282ad0eafaf34fe1ec5bbd73e662f22b6",
+                "sha256:857959354ae3a6fa3da6651b966d13b0a8bed6bbc87a0de7b38a549db1d2a359",
+                "sha256:87f37fe5130574ff76c17cab61e7d2538a16f843bb7bca8ebbc4b12de3078596",
+                "sha256:95d5251e4b5ca00061f9d9f3d6fe537247e145a8524ae9fd30a2f8fbce993b5b",
+                "sha256:9d1d3e63a4afdc29bd76ce6aa9d58c771cd1599fbba8cf5057e7860b203710dd",
+                "sha256:a36c5c154f9d42ec176e6e620cb0dd275744aa1d804786a71ac37dc3661a5e95",
+                "sha256:ae5e35a2c189d397b91034642cb0eab0e346f776ec2eb44a49a459e6615d6e2e",
+                "sha256:b0f7d4a3df8f06cf49f9f121bead236e328074de6449866515cea4907bbc63d6",
+                "sha256:b75110fb114fa366b29a027d0c9be3709579602ae111ff61674d28c93606acca",
+                "sha256:ba5e697569f84b13640c9e193170e89c13c6244c24400fc57e88724ef610cd31",
+                "sha256:be2a9b390f77fd7676d80bc3cdc4f8edb940d8c198ed2d8c0be1319018c778e1",
+                "sha256:d5d8555d9bfc3f02385c1c37e9f998e2011f0db4f90e250e5bc0c0a85a813085",
+                "sha256:e55e22ac0a30023426564b1059b035973ec82186ddddbac867078435801c7801",
+                "sha256:e90f17980e6ab0f3c2f3730e56d1fe9bcba1891eeea58966e89d352492cc74f4",
+                "sha256:ecbb7b01409e9b782df5ded849c178a0aa7c906cf8c5a67368047daab282b184",
+                "sha256:ed01918d545a38998bfa5902c7c00e0fee90e957ce036a4000a88e3fe2264917",
+                "sha256:edabd457cd23a02965166026fd9bfd196f4324fe6032e866d0f3bd0301cd486f",
+                "sha256:fdf1c1dc5bafc32bc5d08b054f94d659422b05aba244d6be4ddc1c72d9aa70fb"
+            ],
+            "markers": "platform_python_implementation != 'pypy'",
+            "version": "==1.11.5"
+        },
         "chardet": {
             "hashes": [
                 "sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae",
                 "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"
             ],
             "version": "==3.0.4"
+        },
+        "cryptography": {
+            "hashes": [
+                "sha256:3f3b65d5a16e6b52fba63dc860b62ca9832f51f1a2ae5083c78b6840275f12dd",
+                "sha256:551a3abfe0c8c6833df4192a63371aa2ff43afd8f570ed345d31f251d78e7e04",
+                "sha256:5cb990056b7cadcca26813311187ad751ea644712022a3976443691168781b6f",
+                "sha256:60bda7f12ecb828358be53095fc9c6edda7de8f1ef571f96c00b2363643fa3cd",
+                "sha256:6fef51ec447fe9f8351894024e94736862900d3a9aa2961528e602eb65c92bdb",
+                "sha256:77d0ad229d47a6e0272d00f6bf8ac06ce14715a9fd02c9a97f5a2869aab3ccb2",
+                "sha256:808fe471b1a6b777f026f7dc7bd9a4959da4bfab64972f2bbe91e22527c1c037",
+                "sha256:9b62fb4d18529c84b961efd9187fecbb48e89aa1a0f9f4161c61b7fc42a101bd",
+                "sha256:9e5bed45ec6b4f828866ac6a6bedf08388ffcfa68abe9e94b34bb40977aba531",
+                "sha256:9fc295bf69130a342e7a19a39d7bbeb15c0bcaabc7382ec33ef3b2b7d18d2f63",
+                "sha256:abd070b5849ed64e6d349199bef955ee0ad99aefbad792f0c587f8effa681a5e",
+                "sha256:ba6a774749b6e510cffc2fb98535f717e0e5fd91c7c99a61d223293df79ab351",
+                "sha256:c332118647f084c983c6a3e1dba0f3bcb051f69d12baccac68db8d62d177eb8a",
+                "sha256:d6f46e862ee36df81e6342c2177ba84e70f722d9dc9c6c394f9f1f434c4a5563",
+                "sha256:db6013746f73bf8edd9c3d1d3f94db635b9422f503db3fc5ef105233d4c011ab",
+                "sha256:f57008eaff597c69cf692c3518f6d4800f0309253bb138b526a37fe9ef0c7471",
+                "sha256:f6c821ac253c19f2ad4c8691633ae1d1a17f120d5b01ea1d256d7b602bc59887"
+            ],
+            "version": "==2.2.2"
         },
         "defusedxml": {
             "hashes": [
@@ -74,6 +142,21 @@
             ],
             "version": "==2.5"
         },
+        "ipify": {
+            "hashes": [
+                "sha256:9941659b9a89a09478b491ec355446b97b8dec1770e317dd56b4c26bbab50840",
+                "sha256:e0d486997e484adbf49008a22b4b5370f675320100ab1af4aaba7e3070fb5d35"
+            ],
+            "index": "pypi",
+            "version": "==1.0.0"
+        },
+        "jeepney": {
+            "hashes": [
+                "sha256:a6f2aa72e61660248d4d524dfccb6405f17c693b69af5d60dd7f2bab807d907e",
+                "sha256:e7b961fe9dfa1ed4c576d3bb2d70a9276dace0e16ebed9da09e4d288fe1d3b2a"
+            ],
+            "version": "==0.3.1"
+        },
         "jmespath": {
             "hashes": [
                 "sha256:6a81d4c9aa62caf061cb517b4d9ad1dd300374cd4706997aff9cd6aedd61fc64",
@@ -83,11 +166,11 @@
         },
         "keyring": {
             "hashes": [
-                "sha256:34886447c5a96605208c4da9bec886c5c9a38c3f6033dc5f927deb14923d241a",
-                "sha256:4a639773932525ff25225cace20e74580403715b3e00a8ea94a7b121dad1cfac"
+                "sha256:4498eaa2e32fc69a8b36749116b670c379d36a1a9ad4ab107df1e19c8a120ffe",
+                "sha256:fd597e72df7240ec5a4215c50957e41c3d4bd321d97bf163f4a8e75ca287d77b"
             ],
             "index": "pypi",
-            "version": "==12.2.0"
+            "version": "==12.2.1"
         },
         "lxml": {
             "hashes": [
@@ -142,11 +225,18 @@
             "index": "pypi",
             "version": "==1.3.1"
         },
+        "pycparser": {
+            "hashes": [
+                "sha256:99a8ca03e29851d96616ad0404b4aad7d9ee16f25c9f9708a11faf2810f7b226"
+            ],
+            "version": "==2.18"
+        },
         "python-dateutil": {
             "hashes": [
                 "sha256:891c38b2a02f5bb1be3e4793866c8df49c7d19baabf9c1bad62547e0b4866aca",
                 "sha256:95511bae634d69bc7329ba55e646499a842bc4ec342ad54a8cdb65645a0aad3c"
             ],
+            "markers": "python_version >= '2.7'",
             "version": "==2.6.1"
         },
         "requests": {
@@ -162,6 +252,14 @@
                 "sha256:c7a9ec356982d5e9ab2d4b46391a7d6a950e2b04c472419f5fdec70cc0ada72f"
             ],
             "version": "==0.1.13"
+        },
+        "secretstorage": {
+            "hashes": [
+                "sha256:1bbf5b85a718854916d1c151fa33e6f667e3c005e033ea46d4123384d233b137",
+                "sha256:819087ca89c0d6c5711692f41fb26f786af9dcc5bb89d567722a66edfbb2a689"
+            ],
+            "markers": "sys_platform == 'linux' and python_version >= '3.5'",
+            "version": "==3.0.1"
         },
         "six": {
             "hashes": [

--- a/README.md
+++ b/README.md
@@ -126,6 +126,12 @@ other sections.
 - `otp_device` - Allow the automatic selection of an OTP device.  
   This value is the human readable string name for the device.
   Eg, `OneLogin Protect`, `Yubico YubiKey`, etc
+- `ip_address` - The client IP address to send to OneLogin.
+  Relevant when using OneLogin Policies with an IP whitelist.
+  If this is specified, `auto_determine_ip_address` is not used.
+- `auto_determine_ip_address` - Automatically determine the client IP address.
+  Relevant when using OneLogin Policies with an IP whitelist.
+  Can be used without specifying `ip_address`.
 
 ### Example
 

--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ save_password = yes
 profile = mycompany-onelogin
 duration_seconds = 3600
 renew_seconds = 60
+auto_determine_ip_address = yes
 
 [testing]
 aws_app_id = 555029

--- a/onelogin_aws_cli/__init__.py
+++ b/onelogin_aws_cli/__init__.py
@@ -1,5 +1,7 @@
 """OneLogin/AWS Business logic"""
 
+from typing import Optional
+
 import configparser
 import xml.etree.ElementTree as ElementTree
 
@@ -80,7 +82,14 @@ class OneloginAWS(object):
 
         self.saml = saml_resp
 
-    def get_ip_address(self):
+    def get_ip_address(self) -> Optional[str]:
+        """
+        Get the client IP address.
+        Uses either the `ip_address` in config,
+        or if `auto_determine_ip_address` is specified in config,
+        the ipify service is used to dynamically lookup the IP address.
+        """
+
         # if ip address has been hard coded in config file, use that
         ip_address = self.config.get('ip_address')
         if ip_address is not None:

--- a/onelogin_aws_cli/__init__.py
+++ b/onelogin_aws_cli/__init__.py
@@ -6,6 +6,9 @@ import xml.etree.ElementTree as ElementTree
 import base64
 import boto3
 import os
+
+import ipify
+
 from onelogin.api.client import OneLoginClient
 
 from onelogin_aws_cli.configuration import Section
@@ -49,10 +52,11 @@ class OneloginAWS(object):
         self.user_credentials.load_credentials()
 
         saml_resp = self.ol_client.get_saml_assertion(
-            self.user_credentials.username,
-            self.user_credentials.password,
-            self.config['aws_app_id'],
-            self.config['subdomain']
+            username_or_email=self.user_credentials.username,
+            password=self.user_credentials.password,
+            app_id=self.config['aws_app_id'],
+            subdomain=self.config['subdomain'],
+            ip_address=self.get_ip_address(),
         )
 
         if saml_resp is None:
@@ -60,6 +64,7 @@ class OneloginAWS(object):
                 error=self.ol_client.error,
                 desc=self.ol_client.error_description
             ))
+
         if saml_resp.mfa:
             if not self.mfa.ready():
                 self.mfa.select_device(saml_resp.mfa.devices)
@@ -74,6 +79,17 @@ class OneloginAWS(object):
             )
 
         self.saml = saml_resp
+
+    def get_ip_address(self):
+        # if ip address has been hard coded in config file, use that
+        ip_address = self.config.get('ip_address')
+        if ip_address is not None:
+            return ip_address
+
+        # if auto determine is enabled, use ipify to lookup the ip
+        if self.config.auto_determine_ip_address:
+            ip_address = ipify.get_ip()
+            return ip_address
 
     def get_arns(self):
         """Extract the IAM Role ARNs from the SAML Assertion"""

--- a/onelogin_aws_cli/configuration.py
+++ b/onelogin_aws_cli/configuration.py
@@ -123,6 +123,13 @@ class Section(object):
         """
         return self.config.getboolean(self.section_name, "save_password")
 
+    @property
+    def auto_determine_ip_address(self):
+        return self.config.getboolean(
+            self.section_name,
+            "auto_determine_ip_address",
+        )
+
     def set_overrides(self, overrides: dict):
         """
         Specify a dictionary values which take precedence over the existing

--- a/onelogin_aws_cli/tests/test_oneloginAWS.py
+++ b/onelogin_aws_cli/tests/test_oneloginAWS.py
@@ -27,7 +27,9 @@ class TestOneloginAWS(TestCase):
             client_id='mock-id',
             client_secret='mock-secret',
             username='mock-username',
-            duration_seconds=2600
+            duration_seconds=2600,
+            ip_address='1.2.3.4',
+            auto_determine_ip_address=False
         ))
         self.ol_with_role = OneloginAWS(dict(
             base_uri="https://api.us.onelogin.com/",
@@ -50,6 +52,12 @@ class TestOneloginAWS(TestCase):
 
         self.assertEqual(mock_config, ol.config)
         self.assertEqual('mock-username', ol.user_credentials.username)
+
+    def test_get_ip_address(self):
+        self.ol.saml = Namespace(saml_response=self.SAML_SINGLE_ROLE)
+        ip_address = self.ol.get_ip_address()
+
+        self.assertEqual('1.2.3.4', ip_address)
 
     def test_get_arns(self):
         self.ol.saml = Namespace(saml_response=self.SAML_SINGLE_ROLE)

--- a/onelogin_aws_cli/tests/test_oneloginAWS_saml.py
+++ b/onelogin_aws_cli/tests/test_oneloginAWS_saml.py
@@ -33,7 +33,8 @@ class TestOneloginSAML(TestCase):
                 subdomain='example',
                 can_save_password=False,
                 username='mock-username',
-                duration_seconds=2600
+                duration_seconds=2600,
+                auto_determine_ip_address=False,
             ),
         )
 
@@ -62,8 +63,11 @@ class TestOneloginSAML(TestCase):
         self.assertEqual(self.ol.saml, 'mock-saml-response')
 
         self.get_saml_assertion_mock.assert_called_with(
-            'mock-username', 'mock-password',
-            'mock-app-id', 'example'
+            username_or_email='mock-username',
+            password='mock-password',
+            app_id='mock-app-id',
+            subdomain='example',
+            ip_address=None,
         )
 
         self.get_saml_assertion_verifying_mock.assert_called_with(
@@ -93,8 +97,11 @@ class TestOneloginSAML(TestCase):
         self.assertEqual(self.ol.saml, 'mock-saml-response')
 
         self.get_saml_assertion_mock.assert_called_with(
-            'mock-username', 'mock-password',
-            'mock-app-id', 'example'
+            username_or_email='mock-username',
+            password='mock-password',
+            app_id='mock-app-id',
+            subdomain='example',
+            ip_address=None,
         )
 
         self.get_saml_assertion_verifying_mock.assert_called_with(
@@ -121,7 +128,8 @@ class TestOneloginSAML(TestCase):
                 aws_app_id='mock-app-id',
                 subdomain='example',
                 can_save_password=False,
-                duration_seconds=2600
+                duration_seconds=2600,
+                auto_determine_ip_address=False,
             ),
         )
         self.assertIsNone(ol.user_credentials.username)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 boto3
 onelogin
 keyring
+ipify

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,8 @@ setuptools.setup(
     install_requires=[
         'boto3',
         'onelogin',
-        'keyring'
+        'keyring',
+        'ipify',
     ],
     setup_requires=['nose>=1.0'],
     entry_points={


### PR DESCRIPTION

## Description

Add support for `ip_address` and `auto_determine_ip_address` options in config file.

## Related Issue

#111 

## Motivation and Context

We use IP whitelists in OneLogin policies to say that clients coming from a certain IP don't have to provide MFA.

This is already supported in the onelogin-python-sdk, this PR just enables support for it.

## How Has This Been Tested?

1. Create an IP whitelist in a Policy in OneLogin.

2. Specify either config option in the config file.
