### PR TITLE
[RFC] Feature/function configs

### DIFF
--- a/onelogin_aws_cli/__init__.py
+++ b/onelogin_aws_cli/__init__.py
@@ -96,7 +96,7 @@ class OneloginAWS(object):
             return ip_address
 
         # if auto determine is enabled, use ipify to lookup the ip
-        if self.config.auto_determine_ip_address:
+        if self.config.get('can_auto_determine_ip_address'):
             ip_address = ipify.get_ip()
             return ip_address
 

--- a/onelogin_aws_cli/cli.py
+++ b/onelogin_aws_cli/cli.py
@@ -23,7 +23,7 @@ def _load_config(parser, config_file: ConfigurationFile, args=sys.argv[1:]):
 
     config_section = config_file.section(cli_args.config_name)
 
-    if config_section is None or not config_section.has_required:
+    if config_section is None or not config_section.get('has_required'):
         sys.exit(
             "Configuration '{}' not defined. "
             "Please run 'onelogin-aws-login -c'".format(

--- a/onelogin_aws_cli/configuration.py
+++ b/onelogin_aws_cli/configuration.py
@@ -106,6 +106,10 @@ class Section(object):
         self.section_name = section_name
         self._overrides = {}
 
+        self._cast_handler_mappings = {
+            'can_': self.config.getboolean
+        }
+
     def _get_has_required(self) -> bool:
         """
         Returns true if the section (including the defaults fallback)
@@ -133,18 +137,15 @@ class Section(object):
         :param item:
         :return:
         """
-        handler_prefixes = ['can_']
-        for prefix in handler_prefixes:
+
+        for prefix in self._cast_handler_mappings.keys():
             if item.startswith(prefix):
                 return True
 
     def _cast_handler(self, item) -> Optional[bool]:
         """Casts the item from string to a type"""
 
-        handler_prefixes = {
-            'can_': self.config.getboolean
-        }
-        for prefix, handler in handler_prefixes.items():
+        for prefix, handler in self._cast_handler_mappings.items():
             if item.startswith(prefix):
                 key = item[len(prefix):]
                 return handler(self.section_name, key)

--- a/onelogin_aws_cli/configuration.py
+++ b/onelogin_aws_cli/configuration.py
@@ -107,7 +107,9 @@ class Section(object):
         self._overrides = {}
 
         self._cast_handler_mappings = {
-            'can_': self.config.getboolean
+            'can_': lambda i: self.config.getboolean(
+                self.section_name, i, fallback=False
+            ),
         }
 
     def _get_has_required(self) -> bool:
@@ -147,7 +149,7 @@ class Section(object):
 
         for prefix, handler in self._cast_handler_mappings.items():
             if item.startswith(prefix):
-                return handler(self.section_name, item[len(prefix):])
+                return handler(item[len(prefix):])
 
     def __setitem__(self, key, value):
         self.config.set(self.section_name, key, value)

--- a/onelogin_aws_cli/configuration.py
+++ b/onelogin_aws_cli/configuration.py
@@ -187,11 +187,16 @@ class Section(object):
 
     def __contains__(self, item):
         func = "_get_" + item
-        return self.config.has_option(self.section_name, item) or \
-               hasattr(self, func) and callable(getattr(self, func)) or \
-               self.config.has_option(self.section_name, item) or \
-               self._has_cast_handler(item) or \
-               item in self.config.DEFAULTS
+
+        has_item_defined = self.config.has_option(self.section_name, raw_item)
+        has_custom_handler = hasattr(self, func) and callable(getattr(self, func))
+        has_cast_handler = self._has_cast_handler(item)
+        has_default_value = raw_item in self.config.DEFAULTS
+
+        return has_item_defined or \
+               has_custom_handler or \
+               has_cast_handler or \
+               has_default_value
 
     def get(self, item, default=None):
         if self.__contains__(item):

--- a/onelogin_aws_cli/configuration.py
+++ b/onelogin_aws_cli/configuration.py
@@ -1,5 +1,6 @@
 """Static User Configuration models"""
 import configparser
+from typing import Optional
 
 from onelogin_aws_cli.userquery import user_choice
 
@@ -143,7 +144,18 @@ class Section(object):
     def __setitem__(self, key, value):
         self.config.set(self.section_name, key, value)
 
-    def __getitem__(self, item):
+    def __getitem__(self, item) -> Optional[str, bool]:
+        """
+        Single location to handle the precedence of configurations.
+        The precedence chain is:
+          - overrides
+          - configuration functions
+          - config files/cli options/environment variables
+          - class level defaults
+
+        :param item: name of the configuration to get.
+        :return:
+        """
         # Is it in the overrides
         if item in self._overrides:
             return self._overrides[item]

--- a/onelogin_aws_cli/configuration.py
+++ b/onelogin_aws_cli/configuration.py
@@ -139,17 +139,15 @@ class Section(object):
         :return:
         """
 
-        for prefix in self._cast_handler_mappings.keys():
-            if item.startswith(prefix):
-                return True
+        return any([item.startswith(prefix)
+                    for prefix in self._cast_handler_mappings.keys()])
 
     def _cast_handler(self, item) -> Optional[bool]:
         """Casts the item from string to a type"""
 
         for prefix, handler in self._cast_handler_mappings.items():
             if item.startswith(prefix):
-                key = item[len(prefix):]
-                return handler(self.section_name, key)
+                return handler(self.section_name, item[len(prefix):])
 
     def __setitem__(self, key, value):
         self.config.set(self.section_name, key, value)

--- a/onelogin_aws_cli/configuration.py
+++ b/onelogin_aws_cli/configuration.py
@@ -131,8 +131,9 @@ class Section(object):
         """
         Checks if the property has a format assuming it has a cast handler
 
-        If an attribute starts with `can_` it will be assumed to be cast as boolean,
-        and the key will be item with `can_` removed from the suffix.
+        If an attribute starts with `can_` it will be assumed to be cast as
+        boolean, and the key will be item with `can_` removed from the
+        suffix.
 
         :param item:
         :return:

--- a/onelogin_aws_cli/credentials.py
+++ b/onelogin_aws_cli/credentials.py
@@ -128,7 +128,7 @@ class UserCredentials(object):
         """
 
         save_password = False
-        reset_password = self.configuration.get('reset_password')
+        reset_password = self.configuration.get('can_reset_password')
 
         # Do we have a password?
         if not self.has_password:

--- a/onelogin_aws_cli/credentials.py
+++ b/onelogin_aws_cli/credentials.py
@@ -133,7 +133,7 @@ class UserCredentials(object):
         # Do we have a password?
         if not self.has_password:
             # Can we load the password from os keychain?
-            if self.configuration.can_save_password:
+            if self.configuration.get('can_save_password'):
 
                 # Load the password from OS keychain
                 self._load_password_from_keychain()

--- a/onelogin_aws_cli/tests/test_configurationFile.py
+++ b/onelogin_aws_cli/tests/test_configurationFile.py
@@ -57,12 +57,12 @@ save_password = true
     def test_can_save_password_username_defaults_false(self):
         cfg = helper.build_config("""[defaults]
 save_password = false""")
-        self.assertFalse(cfg.section("defaults").can_save_password)
+        self.assertFalse(cfg.section("defaults").get('can_save_password'))
 
     def test_can_save_password_username_defaults_true(self):
         cfg = helper.build_config("""[defaults]
 save_password = true""")
-        self.assertTrue(cfg.section("defaults").can_save_password)
+        self.assertTrue(cfg.section("defaults").get('can_save_password'))
 
     def test_initialise(self):
         str = StringIO()

--- a/onelogin_aws_cli/tests/test_configurationFile.py
+++ b/onelogin_aws_cli/tests/test_configurationFile.py
@@ -14,7 +14,7 @@ save_password = true
 
 [profile_test]
 save_password = true""")
-        self.assertTrue(cfg.section("profile_test").can_save_password)
+        self.assertTrue(cfg.section("profile_test").get('can_save_password'))
 
     def test_can_save_password_username_false(self):
         cfg = helper.build_config("""[defaults]
@@ -22,7 +22,7 @@ save_password = false
 
 [profile_test]
 save_password = false""")
-        self.assertFalse(cfg.section("profile_test").can_save_password)
+        self.assertFalse(cfg.section("profile_test").get('can_save_password'))
 
     def test_can_save_password_username_xor_1(self):
         cfg = helper.build_config("""[defaults]
@@ -30,7 +30,7 @@ save_password = false
 
 [profile_test]
 save_password = true""")
-        self.assertTrue(cfg.section("profile_test").can_save_password)
+        self.assertTrue(cfg.section("profile_test").get('can_save_password'))
 
     def test_can_save_password_username_xor_2(self):
         cfg = helper.build_config("""[defaults]
@@ -38,21 +38,21 @@ save_password = true
 
 [profile_test]
 save_password = false""")
-        self.assertFalse(cfg.section("profile_test").can_save_password)
+        self.assertFalse(cfg.section("profile_test").get('can_save_password'))
 
     def test_can_save_password_username_inherit_true(self):
         cfg = helper.build_config("""[defaults]
 save_password = false
 
 [profile_test]""")
-        self.assertFalse(cfg.section("profile_test").can_save_password)
+        self.assertFalse(cfg.section("profile_test").get('can_save_password'))
 
     def test_can_save_password_username_inherit_false(self):
         cfg = helper.build_config("""[defaults]
 save_password = true
 
 [profile_test]""")
-        self.assertTrue(cfg.section("profile_test").can_save_password)
+        self.assertTrue(cfg.section("profile_test").get('can_save_password'))
 
     def test_can_save_password_username_defaults_false(self):
         cfg = helper.build_config("""[defaults]

--- a/onelogin_aws_cli/tests/test_section.py
+++ b/onelogin_aws_cli/tests/test_section.py
@@ -10,6 +10,7 @@ class TestSection(TestCase):
     def test___contains__true(self):
         sec = Section('mock-section', Namespace(
             has_option=MagicMock(return_value=True),
+            DEFAULTS=dict(),
             getboolean=lambda item: item,
         ))
         self.assertTrue('mock' in sec)

--- a/onelogin_aws_cli/tests/test_section.py
+++ b/onelogin_aws_cli/tests/test_section.py
@@ -47,3 +47,11 @@ class TestSection(TestCase):
         ))
 
         self.assertTrue(sec.get('has_required'))
+
+    def test__has_cast_handler(self):
+        sec = Section('mock-section', None)
+
+        self.assertTrue(sec._has_cast_handler('can_mock'))
+
+        self.assertFalse(sec._has_cast_handler('cannot_mock'))
+        self.assertFalse(sec._has_cast_handler('wont_mock'))

--- a/onelogin_aws_cli/tests/test_section.py
+++ b/onelogin_aws_cli/tests/test_section.py
@@ -39,11 +39,11 @@ class TestSection(TestCase):
             has_option=MagicMock(side_effect=lambda s, x: x != 'base_uri')
         ))
 
-        self.assertFalse(sec.has_required)
+        self.assertFalse(sec.get('has_required'))
 
     def test_has_required_true(self):
         sec = Section('mock-section', MagicMock(
             has_option=MagicMock(return_value=True)
         ))
 
-        self.assertTrue(sec.has_required)
+        self.assertTrue(sec.get('has_required'))

--- a/onelogin_aws_cli/tests/test_section.py
+++ b/onelogin_aws_cli/tests/test_section.py
@@ -9,14 +9,16 @@ class TestSection(TestCase):
 
     def test___contains__true(self):
         sec = Section('mock-section', Namespace(
-            has_option=MagicMock(return_value=True)
+            has_option=MagicMock(return_value=True),
+            getboolean=lambda item: item,
         ))
         self.assertTrue('mock' in sec)
 
     def test___contains__false(self):
         sec = Section('mock-section', Namespace(
             has_option=MagicMock(return_value=False),
-            DEFAULTS=dict()
+            DEFAULTS=dict(),
+            getboolean=lambda item: item,
         ))
         self.assertFalse('mock' in sec)
 
@@ -49,7 +51,9 @@ class TestSection(TestCase):
         self.assertTrue(sec.get('has_required'))
 
     def test__has_cast_handler(self):
-        sec = Section('mock-section', None)
+        sec = Section('mock-section', MagicMock(
+            getboolean=lambda item: item,
+        ))
 
         self.assertTrue(sec._has_cast_handler('can_mock'))
 


### PR DESCRIPTION
Wrapped a `@property` methods in a handler so that we can expose all values in `onelogin_aws_cli.Section` as a dictionary value.

## Description
Rather than have special cases for some config attributes, this change will make the access of all config attributes consistent.

## Related Issue
This is tangentially related to the structure of the command in https://github.com/physera/onelogin-aws-cli/pull/114#discussion_r191046435

## Motivation and Context
This reduces the number of ways to access config values from 2 to 1. All configs are access as if they were dictionary k/v pairs.

## How Has This Been Tested?
Test cases have been modified to match new functionality.
