### PR TITLE
Allow user to reset password

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,2 @@
+[*.{md,markdown}]
+trim_trailing_whitespace = false

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ to use the log in functionality
 ## Environment Variables
 
 - `AWS_SHARED_CREDENTIALS_FILE` - Location of the AWS credentials file
-  to write credentials to.
+  to write credentials to.  
   See [AWS CLI Environment Variables](aws-cli-environment-variables)
   for more information.
 - `ONELOGIN_AWS_CLI_CONFIG_NAME` - `onelogin-aws-cli` config section to use.
@@ -104,35 +104,35 @@ other sections.
 
 - `base_uri` - One of either `https://api.us.onelogin.com/` or `https://api.eu.onelogin.com/`
   depending on your OneLogin account.
-- `subdomain` - The subdomain you authenticate against in OneLogin.
+- `subdomain` - The subdomain you authenticate against in OneLogin.  
   This will be the first part of your onelogin domain.
   Eg, In `http://my_company.onelogin.com`, `my_company` would be the subdomain.
-- `username` - Username to be used to authenticate against OneLogin with.
+- `username` - Username to be used to authenticate against OneLogin with.  
   Can also be set with the environment variable `ONELOGIN_AWS_CLI_USERNAME`.
   This functionality supports all keychains supported by
   [keyring](https://pypi.python.org/pypi/keyring).
 - `client_id` - Client ID for the user to use to authenticate against the
-  OneLogin api.
+  OneLogin api.  
   See [Working with API Credentials](https://developers.onelogin.com/api-docs/1/getting-started/working-with-api-credentials)
   for more details.
 - `client_secret` - Client Secret for the user to use to authenticate against
-  the OneLogin api.
+  the OneLogin api.  
   See [Working with API Credentials](https://developers.onelogin.com/api-docs/1/getting-started/working-with-api-credentials)
   for more details.
 - `save_password` - Flag indicating whether `onlogin-aws-cli` can save the
   onelogin password to an OS keychain.
-- `profile` - AWS CLI profile to store credentials in.
+- `profile` - AWS CLI profile to store credentials in.  
   This refers to an AWS CLI profile name defined in your `~./aws/config` file.
-- `duration_seconds` - Length of the IAM STS session in seconds.
+- `duration_seconds` - Length of the IAM STS session in seconds.  
   This cannot exceed the maximum duration specified in AWS for the given role.
 - `aws_app_id` - ID of the AWS App instance in your OneLogin account.
   This ID can be found by logging in to your OneLogin web dashboard
   and navigating to `Administration` -> `APPS` -> `<Your app instance>`,
   and copying it from the URL in the address bar.
-- `role_arn` - AWS Role ARN to assume after authenticating against OneLogin.
+- `role_arn` - AWS Role ARN to assume after authenticating against OneLogin.  
   Specifying this will disable the display of available roles and the
   interactive choice to select a role after authenticating.
-- `otp_device` - Allow the automatic selection of an OTP device.
+- `otp_device` - Allow the automatic selection of an OTP device.  
   This value is the human readable string name for the device.
   Eg, `OneLogin Protect`, `Yubico YubiKey`, etc
 

--- a/README.md
+++ b/README.md
@@ -63,11 +63,24 @@ Use aws cli with --profile 772123451421:role/onelogin-test-s3/myuser@mycompany.c
 ```
 
 
+## Usage
+
+There are two mode of operation for the utility: configure and log in. Specify
+the option `--configure` to enable the configuration of the utility and omit it
+to use the log in functionality
+
+### CLI Options
+
+ - `--configure` - Starts an interactive session which will prompt the user for
+        values to fill out a configuration.
+ - `--reset-password` - Forces a prompt for the user to re-enter their password
+        even if the value is saved to the OS keychain.
+
 
 ## Environment Variables
 
 - `AWS_SHARED_CREDENTIALS_FILE` - Location of the AWS credentials file
-  to write credentials to.  
+  to write credentials to.
   See [AWS CLI Environment Variables](aws-cli-environment-variables)
   for more information.
 - `ONELOGIN_AWS_CLI_CONFIG_NAME` - `onelogin-aws-cli` config section to use.
@@ -82,8 +95,8 @@ Use aws cli with --profile 772123451421:role/onelogin-test-s3/myuser@mycompany.c
 
 ## Configuration File
 
-The configuration file is an `.ini` file with each section referring to a 
-OneLogin AWS application which can be authenticated against. There is also a 
+The configuration file is an `.ini` file with each section referring to a
+OneLogin AWS application which can be authenticated against. There is also a
 special section called `[defaults]` which has values to be used as defaults in
 other sections.
 
@@ -91,35 +104,35 @@ other sections.
 
 - `base_uri` - One of either `https://api.us.onelogin.com/` or `https://api.eu.onelogin.com/`
   depending on your OneLogin account.
-- `subdomain` - The subdomain you authenticate against in OneLogin.  
+- `subdomain` - The subdomain you authenticate against in OneLogin.
   This will be the first part of your onelogin domain.
   Eg, In `http://my_company.onelogin.com`, `my_company` would be the subdomain.
-- `username` - Username to be used to authenticate against OneLogin with.  
+- `username` - Username to be used to authenticate against OneLogin with.
   Can also be set with the environment variable `ONELOGIN_AWS_CLI_USERNAME`.
   This functionality supports all keychains supported by
   [keyring](https://pypi.python.org/pypi/keyring).
 - `client_id` - Client ID for the user to use to authenticate against the
-  OneLogin api.  
+  OneLogin api.
   See [Working with API Credentials](https://developers.onelogin.com/api-docs/1/getting-started/working-with-api-credentials)
   for more details.
 - `client_secret` - Client Secret for the user to use to authenticate against
-  the OneLogin api.  
+  the OneLogin api.
   See [Working with API Credentials](https://developers.onelogin.com/api-docs/1/getting-started/working-with-api-credentials)
   for more details.
 - `save_password` - Flag indicating whether `onlogin-aws-cli` can save the
-  onelogin password to an OS keychain.  
-- `profile` - AWS CLI profile to store credentials in.  
+  onelogin password to an OS keychain.
+- `profile` - AWS CLI profile to store credentials in.
   This refers to an AWS CLI profile name defined in your `~./aws/config` file.
-- `duration_seconds` - Length of the IAM STS session in seconds.  
+- `duration_seconds` - Length of the IAM STS session in seconds.
   This cannot exceed the maximum duration specified in AWS for the given role.
 - `aws_app_id` - ID of the AWS App instance in your OneLogin account.
   This ID can be found by logging in to your OneLogin web dashboard
   and navigating to `Administration` -> `APPS` -> `<Your app instance>`,
   and copying it from the URL in the address bar.
-- `role_arn` - AWS Role ARN to assume after authenticating against OneLogin.  
+- `role_arn` - AWS Role ARN to assume after authenticating against OneLogin.
   Specifying this will disable the display of available roles and the
   interactive choice to select a role after authenticating.
-- `otp_device` - Allow the automatic selection of an OTP device.  
+- `otp_device` - Allow the automatic selection of an OTP device.
   This value is the human readable string name for the device.
   Eg, `OneLogin Protect`, `Yubico YubiKey`, etc
 

--- a/onelogin_aws_cli/argparse.py
+++ b/onelogin_aws_cli/argparse.py
@@ -42,6 +42,12 @@ class OneLoginAWSArgumentParser(argparse.ArgumentParser):
                  '/03/longer-role-sessions/'
         )
 
+        self.add_argument(
+            '--reset-password', dest='reset_password', action='store_true',
+            help='Prompt the user for password even if the password is '
+                 'stored in the OS keychain.', default=False,
+        )
+
         version = pkg_resources.get_distribution(__package__).version
         self.add_argument(
             '-v', '--version', action='version',

--- a/onelogin_aws_cli/configuration.py
+++ b/onelogin_aws_cli/configuration.py
@@ -149,8 +149,8 @@ class Section(object):
 
     def __contains__(self, item):
         return (item in self._overrides) or \
-               self.config.has_option(self.section_name, item) or \
-               item in self.config.DEFAULTS
+            self.config.has_option(self.section_name, item) or \
+            item in self.config.DEFAULTS
 
     def get(self, item, default=None):
         if self.__contains__(item):

--- a/onelogin_aws_cli/configuration.py
+++ b/onelogin_aws_cli/configuration.py
@@ -138,13 +138,15 @@ class Section(object):
         if item in self._overrides:
             return self._overrides[item]
 
-        if item in self:
+        if self.config.has_option(self.section_name, item):
             return self.config.get(self.section_name, item)
 
         return self.config.DEFAULTS[item]
 
     def __contains__(self, item):
-        return self.config.has_option(self.section_name, item)
+        return (item in self._overrides) or \
+            self.config.has_option(self.section_name, item) or \
+            item in self.config.DEFAULTS
 
     def get(self, item, default=None):
         if self.__contains__(item):

--- a/onelogin_aws_cli/configuration.py
+++ b/onelogin_aws_cli/configuration.py
@@ -122,8 +122,10 @@ class Section(object):
         keychain
         :return:
         """
-        return self.config.getboolean(self.section_name, "save_password",
-                                      fallback=self.config.DEFAULTS['save_password'])
+        return self.config.getboolean(
+            self.section_name, "save_password",
+            fallback=self.config.DEFAULTS['save_password']
+        )
 
     def set_overrides(self, overrides: dict):
         """

--- a/onelogin_aws_cli/configuration.py
+++ b/onelogin_aws_cli/configuration.py
@@ -9,6 +9,7 @@ class ConfigurationFile(configparser.ConfigParser):
 
     DEFAULTS = dict(
         save_password=False,
+        reset_password=False,
         duration_seconds=3600
     )
 
@@ -121,7 +122,8 @@ class Section(object):
         keychain
         :return:
         """
-        return self.config.getboolean(self.section_name, "save_password")
+        return self.config.getboolean(self.section_name, "save_password",
+                                      fallback=self.config.DEFAULTS['save_password'])
 
     def set_overrides(self, overrides: dict):
         """
@@ -145,8 +147,8 @@ class Section(object):
 
     def __contains__(self, item):
         return (item in self._overrides) or \
-            self.config.has_option(self.section_name, item) or \
-            item in self.config.DEFAULTS
+               self.config.has_option(self.section_name, item) or \
+               item in self.config.DEFAULTS
 
     def get(self, item, default=None):
         if self.__contains__(item):

--- a/onelogin_aws_cli/credentials.py
+++ b/onelogin_aws_cli/credentials.py
@@ -128,6 +128,7 @@ class UserCredentials(object):
         """
 
         save_password = False
+        reset_password = self.configuration.get('reset_password')
 
         # Do we have a password?
         if not self.has_password:
@@ -138,7 +139,7 @@ class UserCredentials(object):
                 self._load_password_from_keychain()
 
                 # Could not find password in OS keychain
-                if not self.has_password:
+                if not self.has_password or reset_password:
                     # Ask user for password
                     self._prompt_user_password()
                     # Remember to save password

--- a/onelogin_aws_cli/tests/helper.py
+++ b/onelogin_aws_cli/tests/helper.py
@@ -1,0 +1,10 @@
+from io import StringIO
+
+from onelogin_aws_cli.configuration import ConfigurationFile
+
+
+def build_config(config_content: str):
+    str = StringIO()
+    str.write(config_content)
+    str.seek(0)
+    return ConfigurationFile(str)

--- a/onelogin_aws_cli/tests/test_configurationFile.py
+++ b/onelogin_aws_cli/tests/test_configurationFile.py
@@ -110,7 +110,7 @@ save_password = true""")
     def test_section_get_fallback(self):
         cfg = self._helper_build_config("""[profile_test]
 """)
-        self.assertIsNone(cfg.section("profile_test").get("save_password"))
+        self.assertFalse(cfg.section("profile_test").get("save_password"))
 
     def test_has_defaults(self):
 

--- a/onelogin_aws_cli/tests/test_configurationFile.py
+++ b/onelogin_aws_cli/tests/test_configurationFile.py
@@ -1,21 +1,15 @@
+from io import StringIO
 from unittest import TestCase
 from unittest.mock import patch
 
-from io import StringIO
-
 from onelogin_aws_cli.configuration import ConfigurationFile
+from onelogin_aws_cli.tests import helper
 
 
 class TestConfigurationFile(TestCase):
 
-    def _helper_build_config(self, config_content: str):
-        str = StringIO()
-        str.write(config_content)
-        str.seek(0)
-        return ConfigurationFile(str)
-
     def test_can_save_password_username_true(self):
-        cfg = self._helper_build_config("""[defaults]
+        cfg = helper.build_config("""[defaults]
 save_password = true
 
 [profile_test]
@@ -23,7 +17,7 @@ save_password = true""")
         self.assertTrue(cfg.section("profile_test").can_save_password)
 
     def test_can_save_password_username_false(self):
-        cfg = self._helper_build_config("""[defaults]
+        cfg = helper.build_config("""[defaults]
 save_password = false
 
 [profile_test]
@@ -31,7 +25,7 @@ save_password = false""")
         self.assertFalse(cfg.section("profile_test").can_save_password)
 
     def test_can_save_password_username_xor_1(self):
-        cfg = self._helper_build_config("""[defaults]
+        cfg = helper.build_config("""[defaults]
 save_password = false
 
 [profile_test]
@@ -39,7 +33,7 @@ save_password = true""")
         self.assertTrue(cfg.section("profile_test").can_save_password)
 
     def test_can_save_password_username_xor_2(self):
-        cfg = self._helper_build_config("""[defaults]
+        cfg = helper.build_config("""[defaults]
 save_password = true
 
 [profile_test]
@@ -47,26 +41,26 @@ save_password = false""")
         self.assertFalse(cfg.section("profile_test").can_save_password)
 
     def test_can_save_password_username_inherit_true(self):
-        cfg = self._helper_build_config("""[defaults]
+        cfg = helper.build_config("""[defaults]
 save_password = false
 
 [profile_test]""")
         self.assertFalse(cfg.section("profile_test").can_save_password)
 
     def test_can_save_password_username_inherit_false(self):
-        cfg = self._helper_build_config("""[defaults]
+        cfg = helper.build_config("""[defaults]
 save_password = true
 
 [profile_test]""")
         self.assertTrue(cfg.section("profile_test").can_save_password)
 
     def test_can_save_password_username_defaults_false(self):
-        cfg = self._helper_build_config("""[defaults]
+        cfg = helper.build_config("""[defaults]
 save_password = false""")
         self.assertFalse(cfg.section("defaults").can_save_password)
 
     def test_can_save_password_username_defaults_true(self):
-        cfg = self._helper_build_config("""[defaults]
+        cfg = helper.build_config("""[defaults]
 save_password = true""")
         self.assertTrue(cfg.section("defaults").can_save_password)
 
@@ -89,46 +83,43 @@ subdomain = mock_subdomain
 """, str.getvalue())
 
     def test_is_initialised(self):
-
         content = StringIO()
         cf = ConfigurationFile(content)
         self.assertFalse(cf.is_initialised)
 
-        cf = self._helper_build_config("""[section]
+        cf = helper.build_config("""[section]
 first=foo""")
         self.assertTrue(cf.is_initialised)
 
-        cf = self._helper_build_config("""[defaults]
+        cf = helper.build_config("""[defaults]
 first=foo""")
         self.assertTrue(cf.is_initialised)
 
     def test_section_get(self):
-        cfg = self._helper_build_config("""[profile_test]
+        cfg = helper.build_config("""[profile_test]
 save_password = true""")
         self.assertTrue(cfg.section("profile_test").get("save_password"))
 
     def test_section_get_fallback(self):
-        cfg = self._helper_build_config("""[profile_test]
+        cfg = helper.build_config("""[profile_test]
 """)
         self.assertFalse(cfg.section("profile_test").get("save_password"))
 
     def test_has_defaults(self):
-
         content = StringIO()
         cf = ConfigurationFile(content)
         self.assertFalse(cf.has_defaults)
 
-        cf = self._helper_build_config("""[defaults]
+        cf = helper.build_config("""[defaults]
 first=foo""")
         self.assertTrue(cf.has_defaults)
 
     def test_supports_default(self):
-
-        cf = self._helper_build_config("""[defaults]
+        cf = helper.build_config("""[defaults]
 first=foo""")
         self.assertEqual("defaults", cf.default_section)
 
-        cf = self._helper_build_config("""[defaults]
+        cf = helper.build_config("""[defaults]
 first=foo
 
 [default]

--- a/onelogin_aws_cli/tests/test_oneloginAWS.py
+++ b/onelogin_aws_cli/tests/test_oneloginAWS.py
@@ -121,7 +121,7 @@ class TestOneloginAWS(TestCase):
 
     def test__initialize_credentials(self):
         with patch('os.path.expanduser', side_effect=[
-             '/home/.aws/credentials', '/home/.aws/']):
+                '/home/.aws/credentials', '/home/.aws/']):
             with patch('os.path.exists', side_effect=[True]):
                 cred_file = self.ol._initialize_credentials()
                 self.assertEqual('/home/.aws/credentials', cred_file)

--- a/onelogin_aws_cli/tests/test_section.py
+++ b/onelogin_aws_cli/tests/test_section.py
@@ -15,7 +15,8 @@ class TestSection(TestCase):
 
     def test___contains__false(self):
         sec = Section('mock-section', Namespace(
-            has_option=MagicMock(return_value=False)
+            has_option=MagicMock(return_value=False),
+            DEFAULTS=dict()
         ))
         self.assertFalse('mock' in sec)
 

--- a/onelogin_aws_cli/tests/test_userCredentials.py
+++ b/onelogin_aws_cli/tests/test_userCredentials.py
@@ -28,7 +28,7 @@ username = mock_user
     def test_load_password_can_save_fail(self):
         cfg = helper.build_config("""[test-section]
 username = mock_user
-save_password = true        
+save_password = true
 """)
         sec = cfg.section("test-section")
 

--- a/onelogin_aws_cli/tests/test_userCredentials.py
+++ b/onelogin_aws_cli/tests/test_userCredentials.py
@@ -1,0 +1,68 @@
+from unittest import TestCase
+from unittest.mock import MagicMock
+
+from onelogin_aws_cli.credentials import UserCredentials
+from onelogin_aws_cli.tests import helper
+
+
+class TestUserCredentials(TestCase):
+
+    def test_load_password_promptuser(self):
+        cfg = helper.build_config("""[test-section]
+username = mock_user
+""")
+        sec = cfg.section("test-section")
+
+        creds = UserCredentials(sec)
+        creds._load_password_from_keychain = MagicMock()
+        creds._prompt_user_password = MagicMock()
+        creds._save_password_to_keychain = MagicMock()
+
+        creds.load_password()
+
+        creds._load_password_from_keychain.assert_not_called()
+        creds._save_password_to_keychain.assert_not_called()
+
+        creds._prompt_user_password.assert_called_once_with()
+
+    def test_load_password_can_save_fail(self):
+        cfg = helper.build_config("""[test-section]
+username = mock_user
+save_password = true        
+""")
+        sec = cfg.section("test-section")
+
+        creds = UserCredentials(sec)
+        creds._load_password_from_keychain = MagicMock()
+        creds._prompt_user_password = MagicMock()
+        creds._save_password_to_keychain = MagicMock()
+
+        with self.assertRaises(RuntimeError):
+            creds.load_password()
+
+        creds._load_password_from_keychain.assert_called_once_with()
+        creds._prompt_user_password.assert_called_once_with()
+
+        creds._save_password_to_keychain.assert_not_called()
+
+    def test_save_password_success(self):
+        cfg = helper.build_config("""[test-section]
+username = mock_user
+save_password = true
+""")
+        sec = cfg.section("test-section")
+
+        creds = UserCredentials(sec)
+
+        def create_password():
+            creds.password = "mock"
+
+        creds._load_password_from_keychain = MagicMock()
+        creds._prompt_user_password = MagicMock(side_effect=create_password)
+        creds._save_password_to_keychain = MagicMock()
+
+        creds.load_password()
+
+        creds._load_password_from_keychain.assert_called_once_with()
+        creds._prompt_user_password.assert_called_once_with()
+        creds._save_password_to_keychain.assert_called_once_with()

--- a/onelogin_aws_cli/tests/test_userCredentials.py
+++ b/onelogin_aws_cli/tests/test_userCredentials.py
@@ -66,3 +66,30 @@ save_password = true
         creds._load_password_from_keychain.assert_called_once_with()
         creds._prompt_user_password.assert_called_once_with()
         creds._save_password_to_keychain.assert_called_once_with()
+
+    def test_load_password_reset(self):
+        cfg = helper.build_config("""[test-section]
+username = mock_user
+save_password = true
+""")
+        sec = cfg.section("test-section")
+        sec.set_overrides({
+            'reset_password': True
+        })
+
+        creds = UserCredentials(sec)
+
+        def create_password():
+            creds.password = "mock"
+
+        creds._load_password_from_keychain = MagicMock(
+            side_effect=create_password)
+        creds._prompt_user_password = MagicMock(side_effect=create_password)
+        creds._save_password_to_keychain = MagicMock()
+
+        creds.load_password()
+
+        creds._load_password_from_keychain.assert_called_once_with()
+        creds._prompt_user_password.assert_called_once_with()
+
+        creds._save_password_to_keychain.assert_called_once_with()


### PR DESCRIPTION
Added a CLI option to allow the user to reset their password if stored in the OS keychain.

## Description
This change adds a cli option `--reset-password` which enables the user to clear the existing stored password, and enter a new one. If the user has specified to save the password, this functionality is respected and the new password is saved to the keychain.

## Related Issue
The behaviour this PR fixes is described in https://github.com/physera/onelogin-aws-cli/issues/116

## Motivation and Context
Users can now manage their own OS password without understanding how the password storage works.

## How Has This Been Tested?
The test cases have been modified to include a password reset case.
