### PR TITLE
fix error displayed when entering invalid otp

### DIFF
--- a/onelogin_aws_cli/__init__.py
+++ b/onelogin_aws_cli/__init__.py
@@ -79,6 +79,11 @@ class OneloginAWS(object):
                 saml_resp.mfa.state_token,
                 self.mfa.otp
             )
+            if saml_resp is None:
+                raise Exception("Onelogin Error: '{error}' '{desc}'".format(
+                    error=self.ol_client.error,
+                    desc=self.ol_client.error_description
+                ))
 
         self.saml = saml_resp
 

--- a/onelogin_aws_cli/__init__.py
+++ b/onelogin_aws_cli/__init__.py
@@ -45,6 +45,19 @@ class OneloginAWS(object):
             base_uri_parts[1],
         )
 
+    def check_for_errors(self, response):
+        """
+        Throw exceptions that the OneLogin API should have thrown
+        """
+
+        if self.ol_client.error is None:
+            return response
+
+        raise Exception("Onelogin Error: '{error}' '{desc}'".format(
+            error=self.ol_client.error,
+            desc=self.ol_client.error_description
+        ))
+
     def get_saml_assertion(self):
         """
         Retrieve users credentials and get the SAML assertion from Onelogin,
@@ -53,19 +66,15 @@ class OneloginAWS(object):
 
         self.user_credentials.load_credentials()
 
-        saml_resp = self.ol_client.get_saml_assertion(
-            username_or_email=self.user_credentials.username,
-            password=self.user_credentials.password,
-            app_id=self.config['aws_app_id'],
-            subdomain=self.config['subdomain'],
-            ip_address=self.get_ip_address(),
+        saml_resp = self.check_for_errors(
+            self.ol_client.get_saml_assertion(
+                username_or_email=self.user_credentials.username,
+                password=self.user_credentials.password,
+                app_id=self.config['aws_app_id'],
+                subdomain=self.config['subdomain'],
+                ip_address=self.get_ip_address(),
+            )
         )
-
-        if saml_resp is None:
-            raise Exception("Onelogin Error: '{error}' '{desc}'".format(
-                error=self.ol_client.error,
-                desc=self.ol_client.error_description
-            ))
 
         if saml_resp.mfa:
             if not self.mfa.ready():
@@ -73,17 +82,14 @@ class OneloginAWS(object):
                 if not self.mfa.has_otp:
                     self.mfa.prompt_token()
 
-            saml_resp = self.ol_client.get_saml_assertion_verifying(
-                self.config['aws_app_id'],
-                self.mfa.device.id,
-                saml_resp.mfa.state_token,
-                self.mfa.otp
+            saml_resp = self.check_for_errors(
+                self.ol_client.get_saml_assertion_verifying(
+                    self.config['aws_app_id'],
+                    self.mfa.device.id,
+                    saml_resp.mfa.state_token,
+                    self.mfa.otp
+                )
             )
-            if saml_resp is None:
-                raise Exception("Onelogin Error: '{error}' '{desc}'".format(
-                    error=self.ol_client.error,
-                    desc=self.ol_client.error_description
-                ))
 
         self.saml = saml_resp
 


### PR DESCRIPTION
## Description
When fetching saml from onelogin after providing an OTP, no errors were handled. One of the expected errors is the OTP not being valid. Now handles error responses from Onelogin and prints them to the user.

Example message returned when entering an invalid OTP:
```Exception: Onelogin Error: '401' 'Failed authentication with this factor'```


## Related Issue
when typing an invalid otp, the error message was:
```AttributeError: 'NoneType' object has no attribute 'saml_response'```

The stack trace associated with this exception:

```
Traceback (most recent call last):
  File "/usr/local/bin/onelogin-aws-login", line 11, in <module>
    load_entry_point('onelogin-aws-cli==0.1.11', 'console_scripts', 'onelogin-aws-login')()
  File "/usr/local/lib/python3.6/site-packages/onelogin_aws_cli/cli.py", line 65, in login
    raise e
  File "/usr/local/lib/python3.6/site-packages/onelogin_aws_cli/cli.py", line 61, in login
    api.save_credentials()
  File "/usr/local/lib/python3.6/site-packages/onelogin_aws_cli/__init__.py", line 139, in save_credentials
    self.assume_role()
  File "/usr/local/lib/python3.6/site-packages/onelogin_aws_cli/__init__.py", line 125, in assume_role
    self.get_role()
  File "/usr/local/lib/python3.6/site-packages/onelogin_aws_cli/__init__.py", line 108, in get_role
    self.get_arns()
  File "/usr/local/lib/python3.6/site-packages/onelogin_aws_cli/__init__.py", line 86, in get_arns
    base64.b64decode(self.saml.saml_response))
AttributeError: 'NoneType' object has no attribute 'saml_response'
```

## How Has This Been Tested?
Applied patch locally and tested by entering valid/invalid otp