### PR TITLE
auto_determine_ip_address is not a required value

### DIFF
--- a/onelogin_aws_cli/configuration.py
+++ b/onelogin_aws_cli/configuration.py
@@ -10,7 +10,8 @@ class ConfigurationFile(configparser.ConfigParser):
     DEFAULTS = dict(
         save_password=False,
         reset_password=False,
-        duration_seconds=3600
+        duration_seconds=3600,
+        auto_determine_ip_address=False
     )
 
     REQUIRED = [


### PR DESCRIPTION
If `auto_determine_ip_address` is not provided, an error `No option 'auto_determine_ip_address' in section: 'defaults'` is provided

## Description
Added a default value for `auto_determine_ip_address` in the defaults section.