### PR TITLE
Add region option to command line and configuration file.

### DIFF
--- a/onelogin_aws_cli/__init__.py
+++ b/onelogin_aws_cli/__init__.py
@@ -187,7 +187,7 @@ class OneloginAWS(object):
         cred_config[name]['aws_access_key_id'] = creds["AccessKeyId"]
         cred_config[name]['aws_secret_access_key'] = creds["SecretAccessKey"]
         cred_config[name]['aws_session_token'] = creds["SessionToken"]
-        
+
         # Set region for this profile if passed in via configuration
         if self.config['region']:
             cred_config[name]['region'] = self.config['region']

--- a/onelogin_aws_cli/__init__.py
+++ b/onelogin_aws_cli/__init__.py
@@ -181,7 +181,8 @@ class OneloginAWS(object):
         cred_config[name] = {
             "aws_access_key_id": creds["AccessKeyId"],
             "aws_secret_access_key": creds["SecretAccessKey"],
-            "aws_session_token": creds["SessionToken"]
+            "aws_session_token": creds["SessionToken"],
+            "region": self.config['region']
         }
 
         with open(cred_file, "w") as cred_config_file:

--- a/onelogin_aws_cli/__init__.py
+++ b/onelogin_aws_cli/__init__.py
@@ -178,12 +178,15 @@ class OneloginAWS(object):
         if "profile" in self.config:
             name = self.config["profile"]
 
-        cred_config[name] = {
-            "aws_access_key_id": creds["AccessKeyId"],
-            "aws_secret_access_key": creds["SecretAccessKey"],
-            "aws_session_token": creds["SessionToken"],
-            "region": self.config['region']
-        }
+        # Set each value specifically instead of overwriting the entire
+        # profile block in case they have other parameters defined
+        cred_config[name]['aws_access_key_id'] = creds["AccessKeyId"]
+        cred_config[name]['aws_secret_access_key'] = creds["SecretAccessKey"]
+        cred_config[name]['aws_session_token'] = creds["SessionToken"]
+        
+        # Set region for this profile if passed in via configuration
+        if self.config['region']:
+            cred_config[name]['region'] = self.config['region']
 
         with open(cred_file, "w") as cred_config_file:
             cred_config.write(cred_config_file)

--- a/onelogin_aws_cli/__init__.py
+++ b/onelogin_aws_cli/__init__.py
@@ -178,6 +178,10 @@ class OneloginAWS(object):
         if "profile" in self.config:
             name = self.config["profile"]
 
+        # Initialize the profile block if it is undefined
+        if name not in cred_config:
+            cred_config[name] = {}
+
         # Set each value specifically instead of overwriting the entire
         # profile block in case they have other parameters defined
         cred_config[name]['aws_access_key_id'] = creds["AccessKeyId"]

--- a/onelogin_aws_cli/argparse.py
+++ b/onelogin_aws_cli/argparse.py
@@ -28,6 +28,13 @@ class OneLoginAWSArgumentParser(argparse.ArgumentParser):
         )
 
         self.add_argument(
+            '--region',
+            action=EnvDefault, required=False,
+            default=None,
+            help='Specify default region for AWS profile being updated'
+        )
+
+        self.add_argument(
             '-u', '--username',
             action=EnvDefault, required=False,
             help='Specify OneLogin username'

--- a/onelogin_aws_cli/configuration.py
+++ b/onelogin_aws_cli/configuration.py
@@ -11,7 +11,8 @@ class ConfigurationFile(configparser.ConfigParser):
         save_password=False,
         reset_password=False,
         duration_seconds=3600,
-        auto_determine_ip_address=False
+        auto_determine_ip_address=False,
+        region=None
     )
 
     REQUIRED = [

--- a/onelogin_aws_cli/configuration.py
+++ b/onelogin_aws_cli/configuration.py
@@ -20,6 +20,7 @@ class ConfigurationFile(configparser.ConfigParser):
         'client_secret',
         'aws_app_id',
         'subdomain',
+        'region'
     ]
 
     def __init__(self, config_file=None):

--- a/onelogin_aws_cli/configuration.py
+++ b/onelogin_aws_cli/configuration.py
@@ -20,7 +20,6 @@ class ConfigurationFile(configparser.ConfigParser):
         'client_secret',
         'aws_app_id',
         'subdomain',
-        'region'
     ]
 
     def __init__(self, config_file=None):

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 import setuptools
 
 PACKAGE_NAME = 'onelogin_aws_cli'
-VERSION = '0.1.13'
+VERSION = '0.1.14'
 
 setuptools.setup(
     name=PACKAGE_NAME,


### PR DESCRIPTION
## Description
Added region command line option to argparse.py
Added region to the REQUIRED list in configuration.py
Added region to the cred_config[name] block in __init__.py

## Related Issue
Reference issue #125 

## Motivation and Context
We have multiple accounts spanning multiple regions, so a single default region in .aws/config does not meet our needs. We set region in each entry in our .aws/credentials file to manage this. We are currently moving to use OneLogin for all our AWS accounts, and the ability to specify region is critical. Adding it to the onelogin-cli config file allows us to completely control creation of the aws credentials file with the onelogin cli. This simplifies how our development teams work.

## How Has This Been Tested?
We tested all the possible configurations (we thought of) to ensure that we didn't break existing functionality and also handled errors for the new functionality.

## Screenshots (if appropriate):
