### PR TITLE
Fix inconsistent profile names with different AWS partitions

### DIFF
--- a/onelogin_aws_cli/__init__.py
+++ b/onelogin_aws_cli/__init__.py
@@ -8,6 +8,7 @@ import xml.etree.ElementTree as ElementTree
 import base64
 import boto3
 import os
+import re
 
 import ipify
 
@@ -172,8 +173,10 @@ class OneloginAWS(object):
 
         # Update with new credentials
         name = self.credentials["AssumedRoleUser"]["Arn"]
-        if name.startswith("arn:aws:sts::"):
-            name = name[13:]
+        m = re.search('(arn\:aws([\w-]*)\:sts\:\:)(.*)', name)
+
+        if m is not None:
+            name = m.group(3)
         name = name.replace(":assumed-role", "")
         if "profile" in self.config:
             name = self.config["profile"]


### PR DESCRIPTION
## Description

AWS has multiple partitions e.g aws-cn or aws-us-gov which where previously not properly handled and cause not consistent `OneLogin` profile names.

See in addition:

- https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/pseudo-parameter-reference.html#cfn-pseudo-param-partition

## Related Issue

#132 

## Motivation and Context

Unified `OneLogin` profile names in _~/.aws/credentials_

## How Has This Been Tested?

- Run tests with `python setup.py nosetests` 
- Logged into `China` `AWS` account with `onelogin-aws-cli` version 0.1.15
- Logged into `China` `AWS` account with updated version
- Compared the output in _~/.aws/credentials_