### PR TITLE
Make sts client region aware

### DIFF
--- a/onelogin_aws_cli/__init__.py
+++ b/onelogin_aws_cli/__init__.py
@@ -149,6 +149,8 @@ class OneloginAWS(object):
 
         if not self.role_arn:
             self.get_role()
+        if self.config['region']:
+            self.sts_client = boto3.client("sts", region_name=self.config["region"])
         res = self.sts_client.assume_role_with_saml(
             RoleArn=self.role_arn,
             PrincipalArn=self.principal_arn,


### PR DESCRIPTION
## Description

When an AWS region is specified in the configuration file, pick them up
and override initial session with a new session with specified region.

## Related Issue

#125 

## Motivation and Context

Make `onelogin-aws-cli` working for `AWS` `China` accounts in a reliable way

## How Has This Been Tested?

- Run tests with `python setup.py nosetests`
- Logged into `China` `AWS` account with *region* configured in the configuration file
- Logged into a non `China` `AWS` account with updated version without providing *region* at all