### PR TITLE
Fix pep8 violations

### DIFF
--- a/onelogin_aws_cli/__init__.py
+++ b/onelogin_aws_cli/__init__.py
@@ -150,7 +150,9 @@ class OneloginAWS(object):
         if not self.role_arn:
             self.get_role()
         if self.config['region']:
-            self.sts_client = boto3.client("sts", region_name=self.config["region"])
+            self.sts_client = boto3.client(
+                "sts",
+                region_name=self.config["region"])
         res = self.sts_client.assume_role_with_saml(
             RoleArn=self.role_arn,
             PrincipalArn=self.principal_arn,
@@ -175,7 +177,7 @@ class OneloginAWS(object):
 
         # Update with new credentials
         name = self.credentials["AssumedRoleUser"]["Arn"]
-        m = re.search('(arn\:aws([\w-]*)\:sts\:\:)(.*)', name)
+        m = re.search(r'(arn\:aws([\w-]*)\:sts\:\:)(.*)', name)
 
         if m is not None:
             name = m.group(3)

--- a/onelogin_aws_cli/userquery.py
+++ b/onelogin_aws_cli/userquery.py
@@ -8,8 +8,8 @@ RolePrincipalPair = Tuple
 
 def user_choice(question: str,
                 options: List[Any],
-                renderer: Callable[[Any], str]=lambda x: x,
-                saved_choice: str=None):
+                renderer: Callable[[Any], str] = lambda x: x,
+                saved_choice: str = None):
     """
     Prompt a user with a question and a specific set of possible responses
     :param question: Specifying context for the user to select an option
@@ -46,7 +46,7 @@ def user_choice(question: str,
 
 
 def user_role_prompt(all_roles: List[RolePrincipalPair],
-                     saved_choice: str=None) -> RolePrincipalPair:
+                     saved_choice: str = None) -> RolePrincipalPair:
     """
     Prompt a user with a list of AWS IAM roles to choose from. If only 1 role
     is available, return that.


### PR DESCRIPTION
Fixed some pep8 violations. Ran `autopep8 -r -i onelogin_aws_cli/`

## Description
 - Made sure regex is prefixed with 'r'
 - Fixed long lines
 - Added Missing spaces

## Related Issue
 - Blocking #120 

## How Has This Been Tested?
`flake8 .` now passes.
