### PR TITLE
Fix onelogin tests due to missing error field

### DIFF
--- a/onelogin_aws_cli/tests/test_oneloginAWS_saml.py
+++ b/onelogin_aws_cli/tests/test_oneloginAWS_saml.py
@@ -51,7 +51,8 @@ class TestOneloginSAML(TestCase):
         )
         self.ol.ol_client = Namespace(
             get_saml_assertion=self.get_saml_assertion_mock,
-            get_saml_assertion_verifying=self.get_saml_assertion_verifying_mock
+            get_saml_assertion_verifying=self.get_saml_assertion_verifying_mock,
+            error=None,
         )
 
     @mock.patch('getpass.getpass')


### PR DESCRIPTION
#120 improved the error messaging for OTP errors.  However, because it now expects the `ol_client`  object to have an `error` attribute, tests were breaking.  We'll fix this by updating the mock.