### PR TITLE
Added support for specifying the configuration path and to run the CLI as a module

### DIFF
--- a/onelogin_aws_cli/__main__.py
+++ b/onelogin_aws_cli/__main__.py
@@ -1,0 +1,4 @@
+from onelogin_aws_cli import cli
+
+if __name__ == '__main__':
+    cli.login()

--- a/onelogin_aws_cli/argparse.py
+++ b/onelogin_aws_cli/argparse.py
@@ -7,6 +7,8 @@ import os
 
 import pkg_resources
 
+from onelogin_aws_cli import DEFAULT_CONFIG_PATH, OneloginAWS
+
 
 class OneLoginAWSArgumentParser(argparse.ArgumentParser):
     """Argument Parser separated into daemon and cli tool"""
@@ -55,15 +57,22 @@ class OneLoginAWSArgumentParser(argparse.ArgumentParser):
                  'stored in the OS keychain.', default=False,
         )
 
-        version = pkg_resources.get_distribution(__package__).version
         self.add_argument(
-            '-v', '--version', action='version',
-            version="%(prog)s " + version
+            '--config-path',
+            action=EnvDefault, required=False,
+            dest='config_path', default=DEFAULT_CONFIG_PATH,
+            help='Specify the configuration file path'
         )
 
         self.add_argument(
             '-c', '--configure', dest='configure', action='store_true',
             help='Configure OneLogin and AWS settings', default=False
+        )
+
+        version = pkg_resources.get_distribution(__package__).version
+        self.add_argument(
+            '-v', '--version', action='version',
+            version="%(prog)s " + version
         )
 
 

--- a/onelogin_aws_cli/cli.py
+++ b/onelogin_aws_cli/cli.py
@@ -2,10 +2,9 @@
 Collections of entrypoints
 """
 import sys
-
 from os import environ
 
-from onelogin_aws_cli import DEFAULT_CONFIG_PATH, OneloginAWS
+from onelogin_aws_cli import OneloginAWS
 from onelogin_aws_cli.argparse import OneLoginAWSArgumentParser
 from onelogin_aws_cli.configuration import ConfigurationFile
 
@@ -13,7 +12,7 @@ from onelogin_aws_cli.configuration import ConfigurationFile
 def _load_config(parser, config_file: ConfigurationFile, args=sys.argv[1:]):
     cli_args = parser.parse_args(args)
 
-    with open(DEFAULT_CONFIG_PATH, 'a+') as fp:
+    with open(cli_args.config_path, 'a+') as fp:
         fp.seek(0, 0)
         config_file.file = fp
         config_file.load()


### PR DESCRIPTION
Added support for specifying the configuration path and to run the CLI as a module

## Description

1. Now you can change the configuration path both with an argument and with an environment variable.

```
$ python -m onelogin_aws_cli --config-path ~/other-config-file.config
$ ONELOGIN_AWS_CLI_CONFIG_PATH=~/other-config-file.config python -m onelogin_aws_cli
```

2. Now you can run the CLI as a Python module in addition to the installed script as expected in all standard Python packages:

```
$ python -m onelogin_aws_cli -h
```