### PR TITLE
Issue 157: No module named 'onelogin.api.client

### DIFF
--- a/onelogin_aws_cli/tests/test_MFACredentials.py
+++ b/onelogin_aws_cli/tests/test_MFACredentials.py
@@ -70,21 +70,21 @@ class TestMFACredentials(TestCase):
         ]
 
         self.mfa.select_device(devices[:1])
-        self.assertEqual(self.mfa.device.id, '1')
+        self.assertEqual(self.mfa.device.id, 1)
 
         with patch('builtins.input', side_effect=['3']):
             self.mfa.select_device(devices)
 
-        self.assertEqual(self.mfa.device.id, '3')
+        self.assertEqual(self.mfa.device.id, 3)
 
         self.mfa._config["otp_device"] = "DeviceType2"
 
         # Ignores invalid selection
         self.mfa.select_device(devices[:1])
-        self.assertEqual(self.mfa.device.id, '1')
+        self.assertEqual(self.mfa.device.id, 1)
 
         self.mfa.select_device(devices)
-        self.assertEqual(self.mfa.device.id, '2')
+        self.assertEqual(self.mfa.device.id, 2)
 
         del self.mfa._config["otp_device"]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 boto3
-onelogin
+onelogin >= 2.0, < 3.0
 keyring
 requests


### PR DESCRIPTION
Minor change to requirements.txt to address the error.

## Description
This fixes the ModuleNotFoundError by specifying a compatible version of `onelogin` sdk package in the requirements.txt

The recent release of 3.0.0 was a breaking change:
https://github.com/onelogin/onelogin-python-sdk/releases/tag/3.0.0
 
## Related Issue
https://github.com/physera/onelogin-aws-cli/issues/157

Repro steps:
In a new environment with no other python packages install onelogin-aws-cli.  Alternatively, install the requirements in a new venv as described in the README.  Observe that version 3.0.0 of onelogin is installed also.  Then, invocation of the script fails.  The nosetests also fail with similar error.

```sh
python -m pip install onelogin-aws-cli
...

pip show onelogin-aws-cli onelogin
...
Name: onelogin-aws-cli
Version: 0.1.17
...
Requires: boto3, keyring, onelogin, requests
...
ame: onelogin
Version: 3.0.0
Summary: OneLogin API
Home-page: https://onelogin.com
Author: OneLoginDevex
Author-email: support@onelogin.com
License: MIT
Location: <wherever>
Requires: python-dateutil, urllib3
Required-by: onelogin-aws-cli
```

When creating new venv with updated requirements, it will be version 2.0.4 and the tests pass:
```
Name: onelogin
Version: 2.0.4
Summary: OneLogin Python SDK. Use this API client to interact with OneLogin's platform
Home-page: https://github.com/onelogin/onelogin-python-sdk
Author: OneLogin
Author-email: support@onelogin.com
License: MIT
Location: <wherever>
Requires: defusedxml, python-dateutil, requests
Required-by: onelogin-aws-cli
```

## Motivation and Context
Fixes https://github.com/physera/onelogin-aws-cli/issues/157

## How Has This Been Tested?
The nosetests pass when executed as described in README.
