### PR TITLE
Follow up PR #158: Update install_requires version of onelogin to >= 2.0 but < 3.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setuptools.setup(
     py_modules=[PACKAGE_NAME],
     install_requires=[
         'boto3',
-        'onelogin',
+        'onelogin>=2.0,<3.0',
         'keyring',
         'requests',
     ],


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Update incompatible onelogin sdk version in install_requires.

## Description
<!--- Describe your changes in detail -->
It was fixed incompatible onelogin sdk version of requirements.txt in https://github.com/physera/onelogin-aws-cli/pull/158.
But, this PR is not updated install_requires in setup.py.
So, updated them.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/physera/onelogin-aws-cli/issues/157
and PR: https://github.com/physera/onelogin-aws-cli/pull/158

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixies https://github.com/physera/onelogin-aws-cli/issues/157

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
The nosetests pass when executed as described in README.

And install with setup.py in local.

```shell
> pip install -e .
Obtaining file:///Users/yoshitomo.yasuno/workspace/onelogin-aws-cli
  Preparing metadata (setup.py) ... done
Requirement already satisfied: boto3 in ./env/lib/python3.8/site-packages (from onelogin-aws-cli==0.1.18) (1.26.5)
Collecting onelogin<3.0,>=2.0
  Using cached onelogin-2.0.4-py3-none-any.whl (47 kB)
Requirement already satisfied: keyring in ./env/lib/python3.8/site-packages (from onelogin-aws-cli==0.1.18) (23.11.0)
Requirement already satisfied: requests in ./env/lib/python3.8/site-packages (from onelogin-aws-cli==0.1.18) (2.28.1)
Requirement already satisfied: defusedxml>=0.6.0 in ./env/lib/python3.8/site-packages (from onelogin<3.0,>=2.0->onelogin-aws-cli==0.1.18) (0.7.1)
Requirement already satisfied: python-dateutil<3,>=2 in ./env/lib/python3.8/site-packages (from onelogin<3.0,>=2.0->onelogin-aws-cli==0.1.18) (2.8.2)
Requirement already satisfied: charset-normalizer<3,>=2 in ./env/lib/python3.8/site-packages (from requests->onelogin-aws-cli==0.1.18) (2.1.1)
Requirement already satisfied: urllib3<1.27,>=1.21.1 in ./env/lib/python3.8/site-packages (from requests->onelogin-aws-cli==0.1.18) (1.26.12)
Requirement already satisfied: certifi>=2017.4.17 in ./env/lib/python3.8/site-packages (from requests->onelogin-aws-cli==0.1.18) (2022.9.24)
Requirement already satisfied: idna<4,>=2.5 in ./env/lib/python3.8/site-packages (from requests->onelogin-aws-cli==0.1.18) (3.4)
Requirement already satisfied: s3transfer<0.7.0,>=0.6.0 in ./env/lib/python3.8/site-packages (from boto3->onelogin-aws-cli==0.1.18) (0.6.0)
Requirement already satisfied: botocore<1.30.0,>=1.29.5 in ./env/lib/python3.8/site-packages (from boto3->onelogin-aws-cli==0.1.18) (1.29.5)
Requirement already satisfied: jmespath<2.0.0,>=0.7.1 in ./env/lib/python3.8/site-packages (from boto3->onelogin-aws-cli==0.1.18) (1.0.1)
Requirement already satisfied: jaraco.classes in ./env/lib/python3.8/site-packages (from keyring->onelogin-aws-cli==0.1.18) (3.2.3)
Requirement already satisfied: importlib-metadata>=4.11.4 in ./env/lib/python3.8/site-packages (from keyring->onelogin-aws-cli==0.1.18) (5.0.0)
Requirement already satisfied: zipp>=0.5 in ./env/lib/python3.8/site-packages (from importlib-metadata>=4.11.4->keyring->onelogin-aws-cli==0.1.18) (3.10.0)
Requirement already satisfied: six>=1.5 in ./env/lib/python3.8/site-packages (from python-dateutil<3,>=2->onelogin<3.0,>=2.0->onelogin-aws-cli==0.1.18) (1.16.0)
Requirement already satisfied: more-itertools in ./env/lib/python3.8/site-packages (from jaraco.classes->keyring->onelogin-aws-cli==0.1.18) (9.0.0)
Installing collected packages: onelogin, onelogin-aws-cli
  Attempting uninstall: onelogin-aws-cli
    Found existing installation: onelogin-aws-cli 0.1.18
    Uninstalling onelogin-aws-cli-0.1.18:
      Successfully uninstalled onelogin-aws-cli-0.1.18
  Running setup.py develop for onelogin-aws-cli
Successfully installed onelogin-2.0.4 onelogin-aws-cli-0.1.18
WARNING: You are using pip version 22.0.4; however, version 22.3.1 is available.
You should consider upgrading via the '/Users/yoshitomo.yasuno/workspace/onelogin-aws-cli/env/bin/python3 -m pip install --upgrade pip' command.

> pip show onelogin
Name: onelogin
Version: 2.0.4
Summary: OneLogin Python SDK. Use this API client to interact with OneLogin's platform
Home-page: https://github.com/onelogin/onelogin-python-sdk
Author: OneLogin
Author-email: support@onelogin.com
License: MIT
Location: /Users/yoshitomo.yasuno/workspace/onelogin-aws-cli/env/lib/python3.8/site-packages
Requires: defusedxml, python-dateutil, requests
Required-by: onelogin-aws-cli
```